### PR TITLE
Replace bools in public API with enums

### DIFF
--- a/src/Pkcs11Interop.Android/Pkcs11Interop.Android/Pkcs11Interop.Android.csproj
+++ b/src/Pkcs11Interop.Android/Pkcs11Interop.Android/Pkcs11Interop.Android.csproj
@@ -41,6 +41,9 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AppType.cs">
+      <Link>Common\AppType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AttributeValueException.cs">
       <Link>Common\AttributeValueException.cs</Link>
     </Compile>
@@ -101,6 +104,9 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\IMechanismParams.cs">
       <Link>Common\IMechanismParams.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\InitType.cs">
+      <Link>Common\InitType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\LibraryArchitectureException.cs">
       <Link>Common\LibraryArchitectureException.cs</Link>
     </Compile>
@@ -128,6 +134,12 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\Platform.cs">
       <Link>Common\Platform.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SessionType.cs">
+      <Link>Common\SessionType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SlotsType.cs">
+      <Link>Common\SlotsType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnmanagedException.cs">
       <Link>Common\UnmanagedException.cs</Link>
     </Compile>
@@ -139,6 +151,9 @@
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnsupportedPlatformException.cs">
       <Link>Common\UnsupportedPlatformException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\WaitType.cs">
+      <Link>Common\WaitType.cs</Link>
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Doxygen.cs">
       <Link>Doxygen.cs</Link>

--- a/src/Pkcs11Interop.NetStandard/Pkcs11Interop.NetStandard/Pkcs11Interop.NetStandard.csproj
+++ b/src/Pkcs11Interop.NetStandard/Pkcs11Interop.NetStandard/Pkcs11Interop.NetStandard.csproj
@@ -35,6 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AppType.cs">
+      <Link>Common\AppType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AttributeValueException.cs">
       <Link>Common\AttributeValueException.cs</Link>
     </Compile>
@@ -95,6 +98,9 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\IMechanismParams.cs">
       <Link>Common\IMechanismParams.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\InitType.cs">
+      <Link>Common\InitType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\LibraryArchitectureException.cs">
       <Link>Common\LibraryArchitectureException.cs</Link>
     </Compile>
@@ -122,6 +128,12 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\Platform.cs">
       <Link>Common\Platform.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SessionType.cs">
+      <Link>Common\SessionType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SlotsType.cs">
+      <Link>Common\SlotsType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnmanagedException.cs">
       <Link>Common\UnmanagedException.cs</Link>
     </Compile>
@@ -133,6 +145,9 @@
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnsupportedPlatformException.cs">
       <Link>Common\UnsupportedPlatformException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\WaitType.cs">
+      <Link>Common\WaitType.cs</Link>
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Doxygen.cs">
       <Link>Doxygen.cs</Link>

--- a/src/Pkcs11Interop.Silverlight/Pkcs11Interop.Silverlight/Pkcs11Interop.Silverlight.csproj
+++ b/src/Pkcs11Interop.Silverlight/Pkcs11Interop.Silverlight/Pkcs11Interop.Silverlight.csproj
@@ -59,6 +59,9 @@
     <Reference Include="System.Windows" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AppType.cs">
+      <Link>Common\AppType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AttributeValueException.cs">
       <Link>Common\AttributeValueException.cs</Link>
     </Compile>
@@ -119,6 +122,9 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\IMechanismParams.cs">
       <Link>Common\IMechanismParams.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\InitType.cs">
+      <Link>Common\InitType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\LibraryArchitectureException.cs">
       <Link>Common\LibraryArchitectureException.cs</Link>
     </Compile>
@@ -146,6 +152,12 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\Platform.cs">
       <Link>Common\Platform.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SessionType.cs">
+      <Link>Common\SessionType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SlotsType.cs">
+      <Link>Common\SlotsType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnmanagedException.cs">
       <Link>Common\UnmanagedException.cs</Link>
     </Compile>
@@ -157,6 +169,9 @@
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnsupportedPlatformException.cs">
       <Link>Common\UnsupportedPlatformException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\WaitType.cs">
+      <Link>Common\WaitType.cs</Link>
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Doxygen.cs">
       <Link>Doxygen.cs</Link>

--- a/src/Pkcs11Interop.iOS/Pkcs11Interop.iOS/Pkcs11Interop.iOS.csproj
+++ b/src/Pkcs11Interop.iOS/Pkcs11Interop.iOS/Pkcs11Interop.iOS.csproj
@@ -38,6 +38,9 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AppType.cs">
+      <Link>Common\AppType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\AttributeValueException.cs">
       <Link>Common\AttributeValueException.cs</Link>
     </Compile>
@@ -98,6 +101,9 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\IMechanismParams.cs">
       <Link>Common\IMechanismParams.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\InitType.cs">
+      <Link>Common\InitType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\LibraryArchitectureException.cs">
       <Link>Common\LibraryArchitectureException.cs</Link>
     </Compile>
@@ -125,6 +131,12 @@
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\Platform.cs">
       <Link>Common\Platform.cs</Link>
     </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SessionType.cs">
+      <Link>Common\SessionType.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\SlotsType.cs">
+      <Link>Common\SlotsType.cs</Link>
+    </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnmanagedException.cs">
       <Link>Common\UnmanagedException.cs</Link>
     </Compile>
@@ -136,6 +148,9 @@
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\UnsupportedPlatformException.cs">
       <Link>Common\UnsupportedPlatformException.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Common\WaitType.cs">
+      <Link>Common\WaitType.cs</Link>
     </Compile>
     <Compile Include="..\..\Pkcs11Interop\Pkcs11Interop\Doxygen.cs">
       <Link>Doxygen.cs</Link>

--- a/src/Pkcs11Interop/Pkcs11Interop/Common/AppType.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/Common/AppType.cs
@@ -1,0 +1,39 @@
+﻿/*
+ *  Copyright 2012-2017 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  Jaroslav IMRICH <jimrich@jimrich.sk>
+ */
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Type of application that will be using PKCS#11 library
+    /// </summary>
+    public enum AppType
+    {
+        /// <summary>
+        /// Recommended option: PKCS#11 library will be used from multi-threaded application and needs to perform locking with native OS threading model (CKF_OS_LOCKING_OK)
+        /// </summary>
+        MultiThreaded,
+
+        /// <summary>
+        /// PKCS#11 library will be used from single-threaded application and does not need to perform any kind of locking
+        /// </summary>
+        SingleThreaded
+    }
+}

--- a/src/Pkcs11Interop/Pkcs11Interop/Common/InitType.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/Common/InitType.cs
@@ -1,0 +1,39 @@
+﻿/*
+ *  Copyright 2012-2017 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  Jaroslav IMRICH <jimrich@jimrich.sk>
+ */
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Source of PKCS#11 function pointers
+    /// </summary>
+    public enum InitType
+    {
+        /// <summary>
+        /// Recommended option: PKCS#11 function pointers will be acquired with single call of C_GetFunctionList function
+        /// </summary>
+        WithFunctionList,
+
+        /// <summary>
+        /// PKCS#11 function pointers will be acquired with multiple calls of GetProcAddress or dlsym function
+        /// </summary>
+        WithoutFunctionList
+    }
+}

--- a/src/Pkcs11Interop/Pkcs11Interop/Common/SessionType.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/Common/SessionType.cs
@@ -1,0 +1,39 @@
+﻿/*
+ *  Copyright 2012-2017 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  Jaroslav IMRICH <jimrich@jimrich.sk>
+ */
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Type of session
+    /// </summary>
+    public enum SessionType
+    {
+        /// <summary>
+        ///  Read-only session
+        /// </summary>
+        ReadOnly,
+        
+        /// <summary>
+        /// Read-write session
+        /// </summary>
+        ReadWrite
+    }
+}

--- a/src/Pkcs11Interop/Pkcs11Interop/Common/SlotsType.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/Common/SlotsType.cs
@@ -1,0 +1,39 @@
+﻿/*
+ *  Copyright 2012-2017 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  Jaroslav IMRICH <jimrich@jimrich.sk>
+ */
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Type of slots obtained by PKCS#11 library
+    /// </summary>
+    public enum SlotsType
+    {
+        /// <summary>
+        /// Only slots with a token present
+        /// </summary>
+        WithTokenPresent,
+
+        /// <summary>
+        /// All slots (with or without token present)
+        /// </summary>
+        AllSlots
+    }
+}

--- a/src/Pkcs11Interop/Pkcs11Interop/Common/SlotsType.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/Common/SlotsType.cs
@@ -22,7 +22,7 @@
 namespace Net.Pkcs11Interop.Common
 {
     /// <summary>
-    /// Type of slots obtained by PKCS#11 library
+    /// Type of slots to be obtained by PKCS#11 library
     /// </summary>
     public enum SlotsType
     {
@@ -32,8 +32,8 @@ namespace Net.Pkcs11Interop.Common
         WithTokenPresent,
 
         /// <summary>
-        /// All slots (with or without token present)
+        /// All slots regardless of token presence
         /// </summary>
-        AllSlots
+        WithOrWithoutTokenPresent
     }
 }

--- a/src/Pkcs11Interop/Pkcs11Interop/Common/WaitType.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/Common/WaitType.cs
@@ -1,0 +1,39 @@
+﻿/*
+ *  Copyright 2012-2017 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  Jaroslav IMRICH <jimrich@jimrich.sk>
+ */
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Type of waiting for a slot event
+    /// </summary>
+    public enum WaitType
+    {
+        /// <summary>
+        /// Method should block until an event occurs
+        /// </summary>
+        Blocking,
+
+        /// <summary>
+        /// Method should not block until an event occurs
+        /// </summary>
+        NonBlocking
+    }
+}

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11.cs
@@ -247,10 +247,10 @@ namespace Net.Pkcs11Interop.HighLevelAPI
         /// <summary>
         /// Waits for a slot event, such as token insertion or token removal, to occur
         /// </summary>
-        /// <param name="dontBlock">Flag indicating that method should not block until an event occurs - it should return immediately instead. See PKCS#11 standard for full explanation.</param>
+        /// <param name="waitType">Type of waiting for a slot event</param>
         /// <param name="eventOccured">Flag indicating whether event occured</param>
         /// <param name="slotId">PKCS#11 handle of slot that the event occurred in</param>
-        public void WaitForSlotEvent(bool dontBlock, out bool eventOccured, out ulong slotId)
+        public void WaitForSlotEvent(WaitType waitType, out bool eventOccured, out ulong slotId)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
@@ -260,18 +260,18 @@ namespace Net.Pkcs11Interop.HighLevelAPI
                 uint uintSlotId = CK.CK_INVALID_HANDLE;
 
                 if (Platform.StructPackingSize == 0)
-                    _p11_40.WaitForSlotEvent(dontBlock, out eventOccured, out uintSlotId);
+                    _p11_40.WaitForSlotEvent(waitType, out eventOccured, out uintSlotId);
                 else
-                    _p11_41.WaitForSlotEvent(dontBlock, out eventOccured, out uintSlotId);
+                    _p11_41.WaitForSlotEvent(waitType, out eventOccured, out uintSlotId);
                 
                 slotId = uintSlotId;
             }
             else
             {
                 if (Platform.StructPackingSize == 0)
-                    _p11_80.WaitForSlotEvent(dontBlock, out eventOccured, out slotId);
+                    _p11_80.WaitForSlotEvent(waitType, out eventOccured, out slotId);
                 else
-                    _p11_81.WaitForSlotEvent(dontBlock, out eventOccured, out slotId);
+                    _p11_81.WaitForSlotEvent(waitType, out eventOccured, out slotId);
             }
         }
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11.cs
@@ -197,9 +197,9 @@ namespace Net.Pkcs11Interop.HighLevelAPI
         /// <summary>
         /// Obtains a list of slots in the system
         /// </summary>
-        /// <param name="tokenPresent">Flag indicating whether the list obtained includes only those slots with a token present (true), or all slots (false)</param>
+        /// <param name="slotsType">Type of slots to be obtained</param>
         /// <returns>List of available slots</returns>
-        public List<Slot> GetSlotList(bool tokenPresent)
+        public List<Slot> GetSlotList(SlotsType slotsType)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
@@ -210,13 +210,13 @@ namespace Net.Pkcs11Interop.HighLevelAPI
 
                 if (Platform.StructPackingSize == 0)
                 {
-                    List<HighLevelAPI40.Slot> hlaSlotList = _p11_40.GetSlotList(tokenPresent);
+                    List<HighLevelAPI40.Slot> hlaSlotList = _p11_40.GetSlotList(slotsType);
                     foreach (HighLevelAPI40.Slot hlaSlot in hlaSlotList)
                         slotList.Add(new Slot(hlaSlot));
                 }
                 else
                 {
-                    List<HighLevelAPI41.Slot> hlaSlotList = _p11_41.GetSlotList(tokenPresent);
+                    List<HighLevelAPI41.Slot> hlaSlotList = _p11_41.GetSlotList(slotsType);
                     foreach (HighLevelAPI41.Slot hlaSlot in hlaSlotList)
                         slotList.Add(new Slot(hlaSlot));
                 }
@@ -229,13 +229,13 @@ namespace Net.Pkcs11Interop.HighLevelAPI
 
                 if (Platform.StructPackingSize == 0)
                 {
-                    List<HighLevelAPI80.Slot> hlaSlotList = _p11_80.GetSlotList(tokenPresent);
+                    List<HighLevelAPI80.Slot> hlaSlotList = _p11_80.GetSlotList(slotsType);
                     foreach (HighLevelAPI80.Slot hlaSlot in hlaSlotList)
                         slotList.Add(new Slot(hlaSlot));
                 }
                 else
                 {
-                    List<HighLevelAPI81.Slot> hlaSlotList = _p11_81.GetSlotList(tokenPresent);
+                    List<HighLevelAPI81.Slot> hlaSlotList = _p11_81.GetSlotList(slotsType);
                     foreach (HighLevelAPI81.Slot hlaSlot in hlaSlotList)
                         slotList.Add(new Slot(hlaSlot));
                 }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11.cs
@@ -126,22 +126,22 @@ namespace Net.Pkcs11Interop.HighLevelAPI
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        public Pkcs11(string libraryPath, bool useOsLocking)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        public Pkcs11(string libraryPath, AppType appType)
         {
             if (Platform.UnmanagedLongSize == 4)
             {
                 if (Platform.StructPackingSize == 0)
-                    _p11_40 = new HighLevelAPI40.Pkcs11(libraryPath, useOsLocking);
+                    _p11_40 = new HighLevelAPI40.Pkcs11(libraryPath, appType);
                 else
-                    _p11_41 = new HighLevelAPI41.Pkcs11(libraryPath, useOsLocking);
+                    _p11_41 = new HighLevelAPI41.Pkcs11(libraryPath, appType);
             }
             else
             {
                 if (Platform.StructPackingSize == 0)
-                    _p11_80 = new HighLevelAPI80.Pkcs11(libraryPath, useOsLocking);
+                    _p11_80 = new HighLevelAPI80.Pkcs11(libraryPath, appType);
                 else
-                    _p11_81 = new HighLevelAPI81.Pkcs11(libraryPath, useOsLocking);
+                    _p11_81 = new HighLevelAPI81.Pkcs11(libraryPath, appType);
             }
         }
 
@@ -149,23 +149,23 @@ namespace Net.Pkcs11Interop.HighLevelAPI
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        /// <param name="useGetFunctionList">Flag indicating whether cryptoki function pointers should be acquired via C_GetFunctionList (true) or via platform native function (false)</param>
-        public Pkcs11(string libraryPath, bool useOsLocking, bool useGetFunctionList)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        /// <param name="initType">Source of PKCS#11 function pointers</param>
+        public Pkcs11(string libraryPath, AppType appType, InitType initType)
         {
             if (Platform.UnmanagedLongSize == 4)
             {
                 if (Platform.StructPackingSize == 0)
-                    _p11_40 = new HighLevelAPI40.Pkcs11(libraryPath, useOsLocking, useGetFunctionList);
+                    _p11_40 = new HighLevelAPI40.Pkcs11(libraryPath, appType, initType);
                 else
-                    _p11_41 = new HighLevelAPI41.Pkcs11(libraryPath, useOsLocking, useGetFunctionList);
+                    _p11_41 = new HighLevelAPI41.Pkcs11(libraryPath, appType, initType);
             }
             else
             {
                 if (Platform.StructPackingSize == 0)
-                    _p11_80 = new HighLevelAPI80.Pkcs11(libraryPath, useOsLocking, useGetFunctionList);
+                    _p11_80 = new HighLevelAPI80.Pkcs11(libraryPath, appType, initType);
                 else
-                    _p11_81 = new HighLevelAPI81.Pkcs11(libraryPath, useOsLocking, useGetFunctionList);
+                    _p11_81 = new HighLevelAPI81.Pkcs11(libraryPath, appType, initType);
             }
         }
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11UriUtils.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Pkcs11UriUtils.cs
@@ -165,7 +165,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI
             if (!Matches(pkcs11Uri, libraryInfo))
                 return matchingSlots;
 
-            List<Slot> slots = pkcs11.GetSlotList(false);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
             if ((slots == null) || (slots.Count == 0))
                 return slots;
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Slot.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI/Slot.cs
@@ -254,14 +254,14 @@ namespace Net.Pkcs11Interop.HighLevelAPI
         /// <summary>
         /// Opens a session between an application and a token in a particular slot
         /// </summary>
-        /// <param name="readOnly">Flag indicating whether session should be read only</param>
+        /// <param name="sessionType">Type of session to be opened</param>
         /// <returns>Session</returns>
-        public Session OpenSession(bool readOnly)
+        public Session OpenSession(SessionType sessionType)
         {
             if (Platform.UnmanagedLongSize == 4)
-                return (Platform.StructPackingSize == 0) ? new Session(_slot40.OpenSession(readOnly)) : new Session(_slot41.OpenSession(readOnly));
+                return (Platform.StructPackingSize == 0) ? new Session(_slot40.OpenSession(sessionType)) : new Session(_slot41.OpenSession(sessionType));
             else
-                return (Platform.StructPackingSize == 0) ? new Session(_slot80.OpenSession(readOnly)) : new Session(_slot81.OpenSession(readOnly));
+                return (Platform.StructPackingSize == 0) ? new Session(_slot80.OpenSession(sessionType)) : new Session(_slot81.OpenSession(sessionType));
         }
 
         /// <summary>

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11.cs
@@ -147,15 +147,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
         /// <summary>
         /// Obtains a list of slots in the system
         /// </summary>
-        /// <param name="tokenPresent">Flag indicating whether the list obtained includes only those slots with a token present (true), or all slots (false)</param>
+        /// <param name="slotsType">Type of slots to be obtained</param>
         /// <returns>List of available slots</returns>
-        public List<Slot> GetSlotList(bool tokenPresent)
+        public List<Slot> GetSlotList(SlotsType slotsType)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
             uint slotCount = 0;
-            CKR rv = _p11.C_GetSlotList(tokenPresent, null, ref slotCount);
+            CKR rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), null, ref slotCount);
             if (rv != CKR.CKR_OK)
                 throw new Pkcs11Exception("C_GetSlotList", rv);
 
@@ -166,7 +166,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             else
             {
                 uint[] slotList = new uint[slotCount];
-                rv = _p11.C_GetSlotList(tokenPresent, slotList, ref slotCount);
+                rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), slotList, ref slotCount);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_GetSlotList", rv);
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11.cs
@@ -184,19 +184,19 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
         /// <summary>
         /// Waits for a slot event, such as token insertion or token removal, to occur
         /// </summary>
-        /// <param name="dontBlock">Flag indicating that method should not block until an event occurs - it should return immediately instead. See PKCS#11 standard for full explanation.</param>
+        /// <param name="waitType">Type of waiting for a slot event</param>
         /// <param name="eventOccured">Flag indicating whether event occured</param>
         /// <param name="slotId">PKCS#11 handle of slot that the event occurred in</param>
-        public void WaitForSlotEvent(bool dontBlock, out bool eventOccured, out uint slotId)
+        public void WaitForSlotEvent(WaitType waitType, out bool eventOccured, out uint slotId)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
-            uint flags = (dontBlock) ? CKF.CKF_DONT_BLOCK : 0;
+            uint flags = (waitType == WaitType.NonBlocking) ? CKF.CKF_DONT_BLOCK : 0;
 
             uint slotId_ = 0;
             CKR rv = _p11.C_WaitForSlotEvent(flags, ref slotId_, IntPtr.Zero);
-            if (dontBlock)
+            if (waitType == WaitType.NonBlocking)
             {
                 if (rv == CKR.CKR_OK)
                 {

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11.cs
@@ -70,15 +70,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        public Pkcs11(string libraryPath, bool useOsLocking)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        public Pkcs11(string libraryPath, AppType appType)
         {
             _p11 = new LowLevelAPI40.Pkcs11(libraryPath);
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;
@@ -100,16 +100,16 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        /// <param name="useGetFunctionList">Flag indicating whether cryptoki function pointers should be acquired via C_GetFunctionList (true) or via platform native function (false)</param>
-        public Pkcs11(string libraryPath, bool useOsLocking, bool useGetFunctionList)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        /// <param name="initType">Source of PKCS#11 function pointers</param>
+        public Pkcs11(string libraryPath, AppType appType, InitType initType)
         {
-            _p11 = new LowLevelAPI40.Pkcs11(libraryPath, useGetFunctionList);
+            _p11 = new LowLevelAPI40.Pkcs11(libraryPath, (initType == InitType.WithFunctionList));
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11UriUtils.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Pkcs11UriUtils.cs
@@ -165,7 +165,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             if (!Matches(pkcs11Uri, libraryInfo))
                 return matchingSlots;
 
-            List<Slot> slots = pkcs11.GetSlotList(false);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
             if ((slots == null) || (slots.Count == 0))
                 return slots;
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Slot.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Slot.cs
@@ -204,12 +204,12 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
         /// <summary>
         /// Opens a session between an application and a token in a particular slot
         /// </summary>
-        /// <param name="readOnly">Flag indicating whether session should be read only</param>
+        /// <param name="sessionType">Type of session to be opened</param>
         /// <returns>Session</returns>
-        public Session OpenSession(bool readOnly)
+        public Session OpenSession(SessionType sessionType)
         {
             uint flags = CKF.CKF_SERIAL_SESSION;
-            if (!readOnly)
+            if (sessionType == SessionType.ReadWrite)
                 flags = flags | CKF.CKF_RW_SESSION;
 
             uint sessionId = CK.CK_INVALID_HANDLE;

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11.cs
@@ -147,15 +147,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
         /// <summary>
         /// Obtains a list of slots in the system
         /// </summary>
-        /// <param name="tokenPresent">Flag indicating whether the list obtained includes only those slots with a token present (true), or all slots (false)</param>
+        /// <param name="slotsType">Type of slots to be obtained</param>
         /// <returns>List of available slots</returns>
-        public List<Slot> GetSlotList(bool tokenPresent)
+        public List<Slot> GetSlotList(SlotsType slotsType)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
             uint slotCount = 0;
-            CKR rv = _p11.C_GetSlotList(tokenPresent, null, ref slotCount);
+            CKR rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), null, ref slotCount);
             if (rv != CKR.CKR_OK)
                 throw new Pkcs11Exception("C_GetSlotList", rv);
 
@@ -166,7 +166,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             else
             {
                 uint[] slotList = new uint[slotCount];
-                rv = _p11.C_GetSlotList(tokenPresent, slotList, ref slotCount);
+                rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), slotList, ref slotCount);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_GetSlotList", rv);
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11.cs
@@ -184,19 +184,19 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
         /// <summary>
         /// Waits for a slot event, such as token insertion or token removal, to occur
         /// </summary>
-        /// <param name="dontBlock">Flag indicating that method should not block until an event occurs - it should return immediately instead. See PKCS#11 standard for full explanation.</param>
+        /// <param name="waitType">Type of waiting for a slot event</param>
         /// <param name="eventOccured">Flag indicating whether event occured</param>
         /// <param name="slotId">PKCS#11 handle of slot that the event occurred in</param>
-        public void WaitForSlotEvent(bool dontBlock, out bool eventOccured, out uint slotId)
+        public void WaitForSlotEvent(WaitType waitType, out bool eventOccured, out uint slotId)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
-            uint flags = (dontBlock) ? CKF.CKF_DONT_BLOCK : 0;
+            uint flags = (waitType == WaitType.NonBlocking) ? CKF.CKF_DONT_BLOCK : 0;
 
             uint slotId_ = 0;
             CKR rv = _p11.C_WaitForSlotEvent(flags, ref slotId_, IntPtr.Zero);
-            if (dontBlock)
+            if (waitType == WaitType.NonBlocking)
             {
                 if (rv == CKR.CKR_OK)
                 {

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11.cs
@@ -70,15 +70,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        public Pkcs11(string libraryPath, bool useOsLocking)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        public Pkcs11(string libraryPath, AppType appType)
         {
             _p11 = new LowLevelAPI41.Pkcs11(libraryPath);
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;
@@ -100,16 +100,16 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        /// <param name="useGetFunctionList">Flag indicating whether cryptoki function pointers should be acquired via C_GetFunctionList (true) or via platform native function (false)</param>
-        public Pkcs11(string libraryPath, bool useOsLocking, bool useGetFunctionList)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        /// <param name="initType">Source of PKCS#11 function pointers</param>
+        public Pkcs11(string libraryPath, AppType appType, InitType initType)
         {
-            _p11 = new LowLevelAPI41.Pkcs11(libraryPath, useGetFunctionList);
+            _p11 = new LowLevelAPI41.Pkcs11(libraryPath, (initType == InitType.WithFunctionList));
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11UriUtils.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Pkcs11UriUtils.cs
@@ -165,7 +165,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             if (!Matches(pkcs11Uri, libraryInfo))
                 return matchingSlots;
 
-            List<Slot> slots = pkcs11.GetSlotList(false);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
             if ((slots == null) || (slots.Count == 0))
                 return slots;
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Slot.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Slot.cs
@@ -204,12 +204,12 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
         /// <summary>
         /// Opens a session between an application and a token in a particular slot
         /// </summary>
-        /// <param name="readOnly">Flag indicating whether session should be read only</param>
+        /// <param name="sessionType">Type of session to be opened</param>
         /// <returns>Session</returns>
-        public Session OpenSession(bool readOnly)
+        public Session OpenSession(SessionType sessionType)
         {
             uint flags = CKF.CKF_SERIAL_SESSION;
-            if (!readOnly)
+            if (sessionType == SessionType.ReadWrite)
                 flags = flags | CKF.CKF_RW_SESSION;
 
             uint sessionId = CK.CK_INVALID_HANDLE;

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11.cs
@@ -70,15 +70,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        public Pkcs11(string libraryPath, bool useOsLocking)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        public Pkcs11(string libraryPath, AppType appType)
         {
             _p11 = new LowLevelAPI80.Pkcs11(libraryPath);
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;
@@ -100,16 +100,16 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        /// <param name="useGetFunctionList">Flag indicating whether cryptoki function pointers should be acquired via C_GetFunctionList (true) or via platform native function (false)</param>
-        public Pkcs11(string libraryPath, bool useOsLocking, bool useGetFunctionList)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        /// <param name="initType">Source of PKCS#11 function pointers</param>
+        public Pkcs11(string libraryPath, AppType appType, InitType initType)
         {
-            _p11 = new LowLevelAPI80.Pkcs11(libraryPath, useGetFunctionList);
+            _p11 = new LowLevelAPI80.Pkcs11(libraryPath, (initType == InitType.WithFunctionList));
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11.cs
@@ -184,19 +184,19 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
         /// <summary>
         /// Waits for a slot event, such as token insertion or token removal, to occur
         /// </summary>
-        /// <param name="dontBlock">Flag indicating that method should not block until an event occurs - it should return immediately instead. See PKCS#11 standard for full explanation.</param>
+        /// <param name="waitType">Type of waiting for a slot event</param>
         /// <param name="eventOccured">Flag indicating whether event occured</param>
         /// <param name="slotId">PKCS#11 handle of slot that the event occurred in</param>
-        public void WaitForSlotEvent(bool dontBlock, out bool eventOccured, out ulong slotId)
+        public void WaitForSlotEvent(WaitType waitType, out bool eventOccured, out ulong slotId)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
-            ulong flags = (dontBlock) ? CKF.CKF_DONT_BLOCK : 0;
+            ulong flags = (waitType == WaitType.NonBlocking) ? CKF.CKF_DONT_BLOCK : 0;
 
             ulong slotId_ = 0;
             CKR rv = _p11.C_WaitForSlotEvent(flags, ref slotId_, IntPtr.Zero);
-            if (dontBlock)
+            if (waitType == WaitType.NonBlocking)
             {
                 if (rv == CKR.CKR_OK)
                 {

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11.cs
@@ -147,15 +147,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
         /// <summary>
         /// Obtains a list of slots in the system
         /// </summary>
-        /// <param name="tokenPresent">Flag indicating whether the list obtained includes only those slots with a token present (true), or all slots (false)</param>
+        /// <param name="slotsType">Type of slots to be obtained</param>
         /// <returns>List of available slots</returns>
-        public List<Slot> GetSlotList(bool tokenPresent)
+        public List<Slot> GetSlotList(SlotsType slotsType)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
             ulong slotCount = 0;
-            CKR rv = _p11.C_GetSlotList(tokenPresent, null, ref slotCount);
+            CKR rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), null, ref slotCount);
             if (rv != CKR.CKR_OK)
                 throw new Pkcs11Exception("C_GetSlotList", rv);
 
@@ -166,7 +166,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             else
             {
                 ulong[] slotList = new ulong[slotCount];
-                rv = _p11.C_GetSlotList(tokenPresent, slotList, ref slotCount);
+                rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), slotList, ref slotCount);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_GetSlotList", rv);
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11UriUtils.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Pkcs11UriUtils.cs
@@ -165,7 +165,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             if (!Matches(pkcs11Uri, libraryInfo))
                 return matchingSlots;
 
-            List<Slot> slots = pkcs11.GetSlotList(false);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
             if ((slots == null) || (slots.Count == 0))
                 return slots;
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Slot.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Slot.cs
@@ -204,12 +204,12 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
         /// <summary>
         /// Opens a session between an application and a token in a particular slot
         /// </summary>
-        /// <param name="readOnly">Flag indicating whether session should be read only</param>
+        /// <param name="sessionType">Type of session to be opened</param>
         /// <returns>Session</returns>
-        public Session OpenSession(bool readOnly)
+        public Session OpenSession(SessionType sessionType)
         {
             ulong flags = CKF.CKF_SERIAL_SESSION;
-            if (!readOnly)
+            if (sessionType == SessionType.ReadWrite)
                 flags = flags | CKF.CKF_RW_SESSION;
 
             ulong sessionId = CK.CK_INVALID_HANDLE;

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11.cs
@@ -147,15 +147,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
         /// <summary>
         /// Obtains a list of slots in the system
         /// </summary>
-        /// <param name="tokenPresent">Flag indicating whether the list obtained includes only those slots with a token present (true), or all slots (false)</param>
+        /// <param name="slotsType">Type of slots to be obtained</param>
         /// <returns>List of available slots</returns>
-        public List<Slot> GetSlotList(bool tokenPresent)
+        public List<Slot> GetSlotList(SlotsType slotsType)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
             ulong slotCount = 0;
-            CKR rv = _p11.C_GetSlotList(tokenPresent, null, ref slotCount);
+            CKR rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), null, ref slotCount);
             if (rv != CKR.CKR_OK)
                 throw new Pkcs11Exception("C_GetSlotList", rv);
 
@@ -166,7 +166,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             else
             {
                 ulong[] slotList = new ulong[slotCount];
-                rv = _p11.C_GetSlotList(tokenPresent, slotList, ref slotCount);
+                rv = _p11.C_GetSlotList((slotsType == SlotsType.WithTokenPresent), slotList, ref slotCount);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_GetSlotList", rv);
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11.cs
@@ -184,19 +184,19 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
         /// <summary>
         /// Waits for a slot event, such as token insertion or token removal, to occur
         /// </summary>
-        /// <param name="dontBlock">Flag indicating that method should not block until an event occurs - it should return immediately instead. See PKCS#11 standard for full explanation.</param>
+        /// <param name="waitType">Type of waiting for a slot event</param>
         /// <param name="eventOccured">Flag indicating whether event occured</param>
         /// <param name="slotId">PKCS#11 handle of slot that the event occurred in</param>
-        public void WaitForSlotEvent(bool dontBlock, out bool eventOccured, out ulong slotId)
+        public void WaitForSlotEvent(WaitType waitType, out bool eventOccured, out ulong slotId)
         {
             if (this._disposed)
                 throw new ObjectDisposedException(this.GetType().FullName);
 
-            ulong flags = (dontBlock) ? CKF.CKF_DONT_BLOCK : 0;
+            ulong flags = (waitType == WaitType.NonBlocking) ? CKF.CKF_DONT_BLOCK : 0;
 
             ulong slotId_ = 0;
             CKR rv = _p11.C_WaitForSlotEvent(flags, ref slotId_, IntPtr.Zero);
-            if (dontBlock)
+            if (waitType == WaitType.NonBlocking)
             {
                 if (rv == CKR.CKR_OK)
                 {

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11.cs
@@ -70,15 +70,15 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        public Pkcs11(string libraryPath, bool useOsLocking)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        public Pkcs11(string libraryPath, AppType appType)
         {
             _p11 = new LowLevelAPI81.Pkcs11(libraryPath);
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;
@@ -100,16 +100,16 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
         /// Loads and initializes PCKS#11 library
         /// </summary>
         /// <param name="libraryPath">Library name or path</param>
-        /// <param name="useOsLocking">Flag indicating whether PKCS#11 library can use the native operation system threading model for locking. Should be set to true in all multithreaded applications.</param>
-        /// <param name="useGetFunctionList">Flag indicating whether cryptoki function pointers should be acquired via C_GetFunctionList (true) or via platform native function (false)</param>
-        public Pkcs11(string libraryPath, bool useOsLocking, bool useGetFunctionList)
+        /// <param name="appType">Type of application that will be using PKCS#11 library</param>
+        /// <param name="initType">Source of PKCS#11 function pointers</param>
+        public Pkcs11(string libraryPath, AppType appType, InitType initType)
         {
-            _p11 = new LowLevelAPI81.Pkcs11(libraryPath, useGetFunctionList);
+            _p11 = new LowLevelAPI81.Pkcs11(libraryPath, (initType == InitType.WithFunctionList));
 
             try
             {
                 CK_C_INITIALIZE_ARGS initArgs = null;
-                if (useOsLocking)
+                if (appType == AppType.MultiThreaded)
                 {
                     initArgs = new CK_C_INITIALIZE_ARGS();
                     initArgs.Flags = CKF.CKF_OS_LOCKING_OK;

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11UriUtils.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Pkcs11UriUtils.cs
@@ -165,7 +165,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             if (!Matches(pkcs11Uri, libraryInfo))
                 return matchingSlots;
 
-            List<Slot> slots = pkcs11.GetSlotList(false);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
             if ((slots == null) || (slots.Count == 0))
                 return slots;
 

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Slot.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Slot.cs
@@ -204,12 +204,12 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
         /// <summary>
         /// Opens a session between an application and a token in a particular slot
         /// </summary>
-        /// <param name="readOnly">Flag indicating whether session should be read only</param>
+        /// <param name="sessionType">Type of session to be opened</param>
         /// <returns>Session</returns>
-        public Session OpenSession(bool readOnly)
+        public Session OpenSession(SessionType sessionType)
         {
             ulong flags = CKF.CKF_SERIAL_SESSION;
-            if (!readOnly)
+            if (sessionType == SessionType.ReadWrite)
                 flags = flags | CKF.CKF_RW_SESSION;
 
             ulong sessionId = CK.CK_INVALID_HANDLE;

--- a/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
+++ b/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
@@ -43,6 +43,7 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\AppType.cs" />
     <Compile Include="Common\AttributeValueException.cs" />
     <Compile Include="Common\CK.cs" />
     <Compile Include="Common\CKA.cs" />
@@ -63,6 +64,7 @@
     <Compile Include="Common\ConvertUtils.cs" />
     <Compile Include="Common\ElevatedPermissionsMissingException.cs" />
     <Compile Include="Common\IMechanismParams.cs" />
+    <Compile Include="Common\InitType.cs" />
     <Compile Include="Common\LibraryArchitectureException.cs" />
     <Compile Include="Common\NativeMethods.cs" />
     <Compile Include="Common\Pkcs11Exception.cs" />

--- a/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
+++ b/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Common\Pkcs11UriSharedUtils.cs" />
     <Compile Include="Common\Pkcs11UriSpec.cs" />
     <Compile Include="Common\Platform.cs" />
+    <Compile Include="Common\SessionType.cs" />
     <Compile Include="Common\SlotsType.cs" />
     <Compile Include="Common\UnmanagedException.cs" />
     <Compile Include="Common\UnmanagedLibrary.cs" />

--- a/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
+++ b/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Common\Pkcs11UriSharedUtils.cs" />
     <Compile Include="Common\Pkcs11UriSpec.cs" />
     <Compile Include="Common\Platform.cs" />
+    <Compile Include="Common\SlotsType.cs" />
     <Compile Include="Common\UnmanagedException.cs" />
     <Compile Include="Common\UnmanagedLibrary.cs" />
     <Compile Include="Common\UnmanagedMemory.cs" />

--- a/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
+++ b/src/Pkcs11Interop/Pkcs11Interop/Pkcs11Interop.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Common\UnmanagedLibrary.cs" />
     <Compile Include="Common\UnmanagedMemory.cs" />
     <Compile Include="Common\UnsupportedPlatformException.cs" />
+    <Compile Include="Common\WaitType.cs" />
     <Compile Include="Doxygen.cs" />
     <Compile Include="HighLevelAPI40\LibraryInfo.cs" />
     <Compile Include="HighLevelAPI40\Mechanism.cs" />

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/Helpers.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/Helpers.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         public static Slot GetUsableSlot(Pkcs11 pkcs11)
         {
             // Get list of available slots with token present
-            List<Slot> slots = pkcs11.GetSlotList(true);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
 
             Assert.IsNotNull(slots);
             Assert.IsTrue(slots.Count > 0);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_01_InitializeTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_01_InitializeTest.cs
@@ -19,6 +19,7 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
+using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using NUnit.Framework;
 
@@ -39,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
             // Unmanaged PKCS#11 library is loaded by the constructor of Pkcs11 class.
             // Every PKCS#11 library needs to be initialized with C_Initialize method
             // which is also called automatically by the constructor of Pkcs11 class.
-            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking);
+            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType);
             
             // Do something  interesting
             
@@ -57,7 +58,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         {
             // Pkcs11 class can be used in using statement which defines a scope 
             // at the end of which an object will be disposed.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Do something interesting
             }
@@ -70,8 +71,8 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         public void _03_SingleThreadedInitializeTest()
         {
             // If an application will not be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "false" as a value of "useOsLocking" parameter.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, false))
+            // simultaneously, it should specify "AppType.SingleThreaded" as a value of "appType" parameter.
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.SingleThreaded))
             {
                 // Do something interesting
             }
@@ -84,9 +85,9 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         public void _04_MultiThreadedInitializeTest()
         {
             // If an application will be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "true" as a value of "useOsLocking" parameter.
+            // simultaneously, it should specify "AppType.MultiThreaded" as a value of "appType" parameter.
             // PKCS#11 library will use the native operation system threading model for locking.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.MultiThreaded))
             {
                 // Do something interesting
             }
@@ -105,7 +106,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithFunctionList))
             {
                 // Do something interesting
             }
@@ -124,7 +125,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, false))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithoutFunctionList))
             {
                 // Do something interesting
             }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_02_GetInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_02_GetInfoTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicGetInfoTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_03_SlotListInfoAndEventTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_SlotListTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -54,7 +54,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_BasicSlotListAndInfoTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -77,7 +77,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _03_WaitForSlotEventTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Wait for a slot event
                 bool eventOccured = false;

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_03_SlotListInfoAndEventTest.cs
@@ -83,7 +83,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 // Wait for a slot event
                 bool eventOccured = false;
                 ulong slotId = 0;
-                pkcs11.WaitForSlotEvent(true, out eventOccured, out slotId);
+                pkcs11.WaitForSlotEvent(WaitType.NonBlocking, out eventOccured, out slotId);
                 Assert.IsFalse(eventOccured);
             }
         }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_03_SlotListInfoAndEventTest.cs
@@ -20,6 +20,7 @@
  */
 
 using System.Collections.Generic;
+using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using NUnit.Framework;
 
@@ -40,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);
@@ -57,7 +58,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
                 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_04_TokenInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_04_TokenInfoTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicTokenInfoTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_05_MechanismListAndInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_05_MechanismListAndInfoTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicMechanismListAndInfoTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_06_SessionTest.cs
@@ -19,6 +19,7 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
+using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using NUnit.Framework;
 
@@ -42,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
 
                 // Do something interesting in RO session
 
@@ -64,7 +65,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 
                 // Session class can be used in using statement which defines a scope 
                 // at the end of which the session will be closed automatically.
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -83,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 
@@ -104,7 +105,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 Assert.IsNotNull(session);
@@ -126,7 +127,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -145,7 +146,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW (read-write) session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Do something interesting in RW session
                 }
@@ -164,7 +165,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get session details
                     SessionInfo sessionInfo = session.GetSessionInfo();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_06_SessionTest.cs
@@ -36,7 +36,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicSessionTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -57,7 +57,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_UsingSessionTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -77,7 +77,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _03_CloseSessionViaSlotTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -98,7 +98,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _04_CloseAllSessionsTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -120,7 +120,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _05_ReadOnlySessionTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -139,7 +139,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _06_ReadWriteSessionTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -158,7 +158,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _07_SessionInfoTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_07_OperationStateTest.cs
@@ -36,7 +36,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicOperationStateTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_07_OperationStateTest.cs
@@ -19,6 +19,7 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
+using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using NUnit.Framework;
 
@@ -42,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get operation state
                     byte[] state = session.GetOperationState();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_08_LoginTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_NormalUserLoginTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -61,7 +61,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_SecurityOfficerLoginTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_08_LoginTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -67,7 +67,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as SO (security officer)
                     session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_09_InitTokenAndPinTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicInitTokenAndPinTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_09_InitTokenAndPinTest.cs
@@ -51,7 +51,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                     slot.InitToken(Settings.SecurityOfficerPin, Settings.ApplicationName);
 
                     // Open RW session
-                    using (Session session = slot.OpenSession(false))
+                    using (Session session = slot.OpenSession(SessionType.ReadWrite))
                     {
                         // Login as SO (security officer)
                         session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_10_SetPinTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicSetPinTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_10_SetPinTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_11_SeedAndGenerateRandomTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_SeedRandomTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -60,7 +60,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_GenerateRandomTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_11_SeedAndGenerateRandomTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Mix additional seed material into the token's random number generator
                     byte[] seed = ConvertUtils.Utf8StringToBytes("Additional seed material");
@@ -66,7 +66,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get random or pseudo-random data
                     byte[] randomData = session.GenerateRandom(256);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_12_DigestTest.cs
@@ -45,7 +45,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -106,7 +106,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_12_DigestTest.cs
@@ -39,7 +39,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_DigestSinglePartTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -67,7 +67,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_DigestMultiPartTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -100,7 +100,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _03_DigestKeyTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_15_CreateCopyDestroyObjectTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -82,7 +82,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -114,7 +114,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_15_CreateCopyDestroyObjectTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_CreateDestroyObjectTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -76,7 +76,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_CopyObjectTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -108,7 +108,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _03_GetObjectSizeTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_16_GetAndSetAttributeValueTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -81,7 +81,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -122,7 +122,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_16_GetAndSetAttributeValueTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_GetAttributeValueTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -75,7 +75,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_GetInvalidAttributeValueTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -116,7 +116,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _03_SetAttributeValueTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_17_ObjectFindingTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_17_ObjectFindingTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicObjectFindingTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_FindAllObjectsTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_18_GenerateKeyAndKeyPairTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_GenerateKeyTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -78,7 +78,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_GenerateKeyPairTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_18_GenerateKeyAndKeyPairTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_19_EncryptAndDecryptTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -91,7 +91,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -154,7 +154,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_19_EncryptAndDecryptTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_EncryptAndDecryptSinglePartTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -85,7 +85,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_EncryptAndDecryptMultiPartTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -148,7 +148,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _03_EncryptAndDecryptSinglePartOaepTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_20_SignAndVerifyTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_20_SignAndVerifyTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_SignAndVerifySinglePartTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_SignAndVerifyMultiPartTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_21_SignAndVerifyRecoverTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicSignAndVerifyRecoverTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_21_SignAndVerifyRecoverTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicDigestEncryptAndDecryptDigestTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicSignEncryptAndDecryptVerifyTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_24_WrapAndUnwrapKeyTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_24_WrapAndUnwrapKeyTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicWrapAndUnwrapKeyTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_25_DeriveKeyTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_25_DeriveKeyTest.cs
@@ -38,7 +38,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_BasicDeriveKeyTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_26_LegacyParallelFunctionsTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
             
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_26_LegacyParallelFunctionsTest.cs
@@ -37,7 +37,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_GetFunctionStatusTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -65,7 +65,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_CancelFunctionTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27_Pkcs11UriUtilsTest.cs
@@ -106,7 +106,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                     throw new Exception("None of the slots matches PKCS#11 URI");
 
                 // Open read only session with first token that matches URI
-                using (Session session = slots[0].OpenSession(true))
+                using (Session session = slots[0].OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user with PIN acquired from URI
                     session.Login(CKU.CKU_USER, pkcs11Uri.PinValue);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27_Pkcs11UriUtilsTest.cs
@@ -98,7 +98,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 throw new Exception("PKCS#11 URI does not specify private key");
 
             // Load and initialize PKCS#11 library specified by URI
-            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, AppType.MultiThreaded))
             {
                 // Obtain a list of all slots with tokens that match URI
                 List<Slot> slots = Pkcs11UriUtils.GetMatchingSlotList(pkcs11Uri, pkcs11, true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27b_Pkcs11UriUtilsTest.cs
@@ -39,7 +39,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _02_LibraryInfoMatches()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 
@@ -91,7 +91,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _03_SlotInfoMatches()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -145,7 +145,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _04_TokenInfoMatches()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -320,7 +320,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _06_GetMatchingSlotList()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
                 List<Slot> allSlots = pkcs11.GetSlotList(true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_27b_Pkcs11UriUtilsTest.cs
@@ -93,7 +93,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         {
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 SlotInfo slotInfo = slots[0].GetSlotInfo();
 
@@ -147,7 +147,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         {
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 TokenInfo tokenInfo = slots[0].GetTokenInfo();
 
@@ -323,7 +323,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
-                List<Slot> allSlots = pkcs11.GetSlotList(true);
+                List<Slot> allSlots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(allSlots != null && allSlots.Count > 0);
 
                 // Empty URI

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_28_Pkcs11ClassExtensionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_28_Pkcs11ClassExtensionTest.cs
@@ -375,7 +375,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_StructSizeListTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
                 if (libraryInfo.LibraryDescription != "Mock module" && libraryInfo.ManufacturerId != "Pkcs11Interop Project")

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_29_SlotClassExtensionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_29_SlotClassExtensionTest.cs
@@ -281,7 +281,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_EjectTokenTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
                 if (libraryInfo.LibraryDescription != "Mock module" && libraryInfo.ManufacturerId != "Pkcs11Interop Project")

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_30_SessionClassExtensionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_30_SessionClassExtensionTest.cs
@@ -291,7 +291,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Login interactively via vendor specific function C_EjectToken
                     session.InteractiveLogin();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_30_SessionClassExtensionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI/_30_SessionClassExtensionTest.cs
@@ -281,7 +281,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI
         [Test()]
         public void _01_InteractiveLoginTest()
         {
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
                 if (libraryInfo.LibraryDescription != "Mock module" && libraryInfo.ManufacturerId != "Pkcs11Interop Project")

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/Helpers.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/Helpers.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
         public static Slot GetUsableSlot(Pkcs11 pkcs11)
         {
             // Get list of available slots with token present
-            List<Slot> slots = pkcs11.GetSlotList(true);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
 
             Assert.IsNotNull(slots);
             Assert.IsTrue(slots.Count > 0);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_01_InitializeTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_01_InitializeTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             // Unmanaged PKCS#11 library is loaded by the constructor of Pkcs11 class.
             // Every PKCS#11 library needs to be initialized with C_Initialize method
             // which is also called automatically by the constructor of Pkcs11 class.
-            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking);
+            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType);
             
             // Do something  interesting
             
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
 
             // Pkcs11 class can be used in using statement which defines a scope 
             // at the end of which an object will be disposed.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Do something interesting
             }
@@ -80,8 +80,8 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will not be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "false" as a value of "useOsLocking" parameter.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, false))
+            // simultaneously, it should specify "AppType.SingleThreaded" as a value of "appType" parameter.
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.SingleThreaded))
             {
                 // Do something interesting
             }
@@ -97,9 +97,9 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "true" as a value of "useOsLocking" parameter.
+            // simultaneously, it should specify "AppType.MultiThreaded" as a value of "appType" parameter.
             // PKCS#11 library will use the native operation system threading model for locking.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.MultiThreaded))
             {
                 // Do something interesting
             }
@@ -121,7 +121,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI40.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithFunctionList))
             {
                 // Do something interesting
             }
@@ -143,7 +143,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI40.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, false))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithoutFunctionList))
             {
                 // Do something interesting
             }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_02_GetInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_02_GetInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_03_SlotListInfoAndEventTest.cs
@@ -92,7 +92,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 // Wait for a slot event
                 bool eventOccured = false;
                 uint slotId = 0;
-                pkcs11.WaitForSlotEvent(true, out eventOccured, out slotId);
+                pkcs11.WaitForSlotEvent(WaitType.NonBlocking, out eventOccured, out slotId);
                 Assert.IsFalse(eventOccured);
             }
         }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_03_SlotListInfoAndEventTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -61,7 +61,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Wait for a slot event
                 bool eventOccured = false;

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_03_SlotListInfoAndEventTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
                 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_04_TokenInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_04_TokenInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_05_MechanismListAndInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_05_MechanismListAndInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_06_SessionTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
 
                 // Do something interesting in RO session
 
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 
                 // Session class can be used in using statement which defines a scope 
                 // at the end of which the session will be closed automatically.
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -93,7 +93,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 Assert.IsNotNull(session);
@@ -142,7 +142,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -164,7 +164,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW (read-write) session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Do something interesting in RW session
                 }
@@ -186,7 +186,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get session details
                     SessionInfo sessionInfo = session.GetSessionInfo();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_06_SessionTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -111,7 +111,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -136,7 +136,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -158,7 +158,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -180,7 +180,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_07_OperationStateTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get operation state
                     byte[] state = session.GetOperationState();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_07_OperationStateTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_08_LoginTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as SO (security officer)
                     session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_08_LoginTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -67,7 +67,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_09_InitTokenAndPinTest.cs
@@ -54,7 +54,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                     slot.InitToken(Settings.SecurityOfficerPin, Settings.ApplicationName);
 
                     // Open RW session
-                    using (Session session = slot.OpenSession(false))
+                    using (Session session = slot.OpenSession(SessionType.ReadWrite))
                     {
                         // Login as SO (security officer)
                         session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_09_InitTokenAndPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_10_SetPinTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_10_SetPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_11_SeedAndGenerateRandomTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -66,7 +66,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_11_SeedAndGenerateRandomTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Mix additional seed material into the token's random number generator
                     byte[] seed = ConvertUtils.Utf8StringToBytes("Additional seed material");
@@ -72,7 +72,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get random or pseudo-random data
                     byte[] randomData = session.GenerateRandom(256);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_12_DigestTest.cs
@@ -48,7 +48,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -79,7 +79,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -115,7 +115,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_12_DigestTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_15_CreateCopyDestroyObjectTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -88,7 +88,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -123,7 +123,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_15_CreateCopyDestroyObjectTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -82,7 +82,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_16_GetAndSetAttributeValueTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -131,7 +131,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_16_GetAndSetAttributeValueTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -81,7 +81,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -125,7 +125,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_17_ObjectFindingTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_17_ObjectFindingTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_18_GenerateKeyAndKeyPairTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_18_GenerateKeyAndKeyPairTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_19_EncryptAndDecryptTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -91,7 +91,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -157,7 +157,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_19_EncryptAndDecryptTest.cs
@@ -49,7 +49,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -163,7 +163,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_20_SignAndVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_20_SignAndVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_21_SignAndVerifyRecoverTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_21_SignAndVerifyRecoverTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_24_WrapAndUnwrapKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_24_WrapAndUnwrapKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_25_DeriveKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_25_DeriveKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_26_LegacyParallelFunctionsTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try
@@ -77,7 +77,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
             
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_26_LegacyParallelFunctionsTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27_Pkcs11UriUtilsTest.cs
@@ -101,7 +101,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                 throw new Exception("PKCS#11 URI does not specify private key");
 
             // Load and initialize PKCS#11 library specified by URI
-            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, AppType.MultiThreaded))
             {
                 // Obtain a list of all slots with tokens that match URI
                 List<Slot> slots = Pkcs11UriUtils.GetMatchingSlotList(pkcs11Uri, pkcs11, true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27_Pkcs11UriUtilsTest.cs
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
                     throw new Exception("None of the slots matches PKCS#11 URI");
 
                 // Open read only session with first token that matches URI
-                using (Session session = slots[0].OpenSession(true))
+                using (Session session = slots[0].OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user with PIN acquired from URI
                     session.Login(CKU.CKU_USER, pkcs11Uri.PinValue);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27b_Pkcs11UriUtilsTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -154,7 +154,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -335,7 +335,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
                 List<Slot> allSlots = pkcs11.GetSlotList(true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI40/_27b_Pkcs11UriUtilsTest.cs
@@ -99,7 +99,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 SlotInfo slotInfo = slots[0].GetSlotInfo();
 
@@ -156,7 +156,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 TokenInfo tokenInfo = slots[0].GetTokenInfo();
 
@@ -338,7 +338,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI40
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
-                List<Slot> allSlots = pkcs11.GetSlotList(true);
+                List<Slot> allSlots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(allSlots != null && allSlots.Count > 0);
 
                 // Empty URI

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/Helpers.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/Helpers.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
         public static Slot GetUsableSlot(Pkcs11 pkcs11)
         {
             // Get list of available slots with token present
-            List<Slot> slots = pkcs11.GetSlotList(true);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
 
             Assert.IsNotNull(slots);
             Assert.IsTrue(slots.Count > 0);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_01_InitializeTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_01_InitializeTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             // Unmanaged PKCS#11 library is loaded by the constructor of Pkcs11 class.
             // Every PKCS#11 library needs to be initialized with C_Initialize method
             // which is also called automatically by the constructor of Pkcs11 class.
-            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking);
+            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType);
             
             // Do something  interesting
             
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
 
             // Pkcs11 class can be used in using statement which defines a scope 
             // at the end of which an object will be disposed.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Do something interesting
             }
@@ -80,8 +80,8 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will not be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "false" as a value of "useOsLocking" parameter.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, false))
+            // simultaneously, it should specify "AppType.SingleThreaded" as a value of "appType" parameter.
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.SingleThreaded))
             {
                 // Do something interesting
             }
@@ -97,9 +97,9 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "true" as a value of "useOsLocking" parameter.
+            // simultaneously, it should specify "AppType.MultiThreaded" as a value of "appType" parameter.
             // PKCS#11 library will use the native operation system threading model for locking.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.MultiThreaded))
             {
                 // Do something interesting
             }
@@ -121,7 +121,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI41.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithFunctionList))
             {
                 // Do something interesting
             }
@@ -143,7 +143,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI41.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, false))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithoutFunctionList))
             {
                 // Do something interesting
             }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_02_GetInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_02_GetInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_03_SlotListInfoAndEventTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -61,7 +61,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Wait for a slot event
                 bool eventOccured = false;

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_03_SlotListInfoAndEventTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
                 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_03_SlotListInfoAndEventTest.cs
@@ -92,7 +92,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 // Wait for a slot event
                 bool eventOccured = false;
                 uint slotId = 0;
-                pkcs11.WaitForSlotEvent(true, out eventOccured, out slotId);
+                pkcs11.WaitForSlotEvent(WaitType.NonBlocking, out eventOccured, out slotId);
                 Assert.IsFalse(eventOccured);
             }
         }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_04_TokenInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_04_TokenInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_05_MechanismListAndInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_05_MechanismListAndInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_06_SessionTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -111,7 +111,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -136,7 +136,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -158,7 +158,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -180,7 +180,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_06_SessionTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
 
                 // Do something interesting in RO session
 
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 
                 // Session class can be used in using statement which defines a scope 
                 // at the end of which the session will be closed automatically.
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -93,7 +93,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 Assert.IsNotNull(session);
@@ -142,7 +142,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -164,7 +164,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW (read-write) session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Do something interesting in RW session
                 }
@@ -186,7 +186,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get session details
                     SessionInfo sessionInfo = session.GetSessionInfo();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_07_OperationStateTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get operation state
                     byte[] state = session.GetOperationState();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_07_OperationStateTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_08_LoginTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as SO (security officer)
                     session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_08_LoginTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -67,7 +67,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_09_InitTokenAndPinTest.cs
@@ -54,7 +54,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                     slot.InitToken(Settings.SecurityOfficerPin, Settings.ApplicationName);
 
                     // Open RW session
-                    using (Session session = slot.OpenSession(false))
+                    using (Session session = slot.OpenSession(SessionType.ReadWrite))
                     {
                         // Login as SO (security officer)
                         session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_09_InitTokenAndPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_10_SetPinTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_10_SetPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_11_SeedAndGenerateRandomTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Mix additional seed material into the token's random number generator
                     byte[] seed = ConvertUtils.Utf8StringToBytes("Additional seed material");
@@ -72,7 +72,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get random or pseudo-random data
                     byte[] randomData = session.GenerateRandom(256);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_11_SeedAndGenerateRandomTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -66,7 +66,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_12_DigestTest.cs
@@ -48,7 +48,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -79,7 +79,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -115,7 +115,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_12_DigestTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_15_CreateCopyDestroyObjectTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -82,7 +82,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_15_CreateCopyDestroyObjectTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -88,7 +88,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -123,7 +123,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_16_GetAndSetAttributeValueTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -81,7 +81,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -125,7 +125,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_16_GetAndSetAttributeValueTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -131,7 +131,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_17_ObjectFindingTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_17_ObjectFindingTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_18_GenerateKeyAndKeyPairTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_18_GenerateKeyAndKeyPairTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_19_EncryptAndDecryptTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -91,7 +91,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -157,7 +157,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_19_EncryptAndDecryptTest.cs
@@ -49,7 +49,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -163,7 +163,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_20_SignAndVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_20_SignAndVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_21_SignAndVerifyRecoverTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_21_SignAndVerifyRecoverTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_24_WrapAndUnwrapKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_24_WrapAndUnwrapKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_25_DeriveKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_25_DeriveKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_26_LegacyParallelFunctionsTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try
@@ -77,7 +77,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
             
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_26_LegacyParallelFunctionsTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27_Pkcs11UriUtilsTest.cs
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                     throw new Exception("None of the slots matches PKCS#11 URI");
 
                 // Open read only session with first token that matches URI
-                using (Session session = slots[0].OpenSession(true))
+                using (Session session = slots[0].OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user with PIN acquired from URI
                     session.Login(CKU.CKU_USER, pkcs11Uri.PinValue);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27_Pkcs11UriUtilsTest.cs
@@ -101,7 +101,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
                 throw new Exception("PKCS#11 URI does not specify private key");
 
             // Load and initialize PKCS#11 library specified by URI
-            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, AppType.MultiThreaded))
             {
                 // Obtain a list of all slots with tokens that match URI
                 List<Slot> slots = Pkcs11UriUtils.GetMatchingSlotList(pkcs11Uri, pkcs11, true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27b_Pkcs11UriUtilsTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -154,7 +154,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -335,7 +335,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
                 List<Slot> allSlots = pkcs11.GetSlotList(true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI41/_27b_Pkcs11UriUtilsTest.cs
@@ -99,7 +99,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 SlotInfo slotInfo = slots[0].GetSlotInfo();
 
@@ -156,7 +156,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 TokenInfo tokenInfo = slots[0].GetTokenInfo();
 
@@ -338,7 +338,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI41
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
-                List<Slot> allSlots = pkcs11.GetSlotList(true);
+                List<Slot> allSlots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(allSlots != null && allSlots.Count > 0);
 
                 // Empty URI

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/Helpers.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/Helpers.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
         public static Slot GetUsableSlot(Pkcs11 pkcs11)
         {
             // Get list of available slots with token present
-            List<Slot> slots = pkcs11.GetSlotList(true);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
 
             Assert.IsNotNull(slots);
             Assert.IsTrue(slots.Count > 0);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_01_InitializeTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_01_InitializeTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             // Unmanaged PKCS#11 library is loaded by the constructor of Pkcs11 class.
             // Every PKCS#11 library needs to be initialized with C_Initialize method
             // which is also called automatically by the constructor of Pkcs11 class.
-            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking);
+            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType);
             
             // Do something  interesting
             
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
 
             // Pkcs11 class can be used in using statement which defines a scope 
             // at the end of which an object will be disposed.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Do something interesting
             }
@@ -80,8 +80,8 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will not be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "false" as a value of "useOsLocking" parameter.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, false))
+            // simultaneously, it should specify "AppType.SingleThreaded" as a value of "appType" parameter.
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.SingleThreaded))
             {
                 // Do something interesting
             }
@@ -97,9 +97,9 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "true" as a value of "useOsLocking" parameter.
+            // simultaneously, it should specify "AppType.MultiThreaded" as a value of "appType" parameter.
             // PKCS#11 library will use the native operation system threading model for locking.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.MultiThreaded))
             {
                 // Do something interesting
             }
@@ -121,7 +121,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI80.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithFunctionList))
             {
                 // Do something interesting
             }
@@ -143,7 +143,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI80.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, false))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithoutFunctionList))
             {
                 // Do something interesting
             }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_02_GetInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_02_GetInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_03_SlotListInfoAndEventTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -61,7 +61,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Wait for a slot event
                 bool eventOccured = false;

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_03_SlotListInfoAndEventTest.cs
@@ -92,7 +92,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 // Wait for a slot event
                 bool eventOccured = false;
                 ulong slotId = 0;
-                pkcs11.WaitForSlotEvent(true, out eventOccured, out slotId);
+                pkcs11.WaitForSlotEvent(WaitType.NonBlocking, out eventOccured, out slotId);
                 Assert.IsFalse(eventOccured);
             }
         }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_03_SlotListInfoAndEventTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
                 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_04_TokenInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_04_TokenInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_05_MechanismListAndInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_05_MechanismListAndInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_06_SessionTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
 
                 // Do something interesting in RO session
 
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 
                 // Session class can be used in using statement which defines a scope 
                 // at the end of which the session will be closed automatically.
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -93,7 +93,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 Assert.IsNotNull(session);
@@ -142,7 +142,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -164,7 +164,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW (read-write) session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Do something interesting in RW session
                 }
@@ -186,7 +186,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get session details
                     SessionInfo sessionInfo = session.GetSessionInfo();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_06_SessionTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -111,7 +111,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -136,7 +136,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -158,7 +158,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -180,7 +180,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_07_OperationStateTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_07_OperationStateTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get operation state
                     byte[] state = session.GetOperationState();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_08_LoginTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as SO (security officer)
                     session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_08_LoginTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -67,7 +67,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_09_InitTokenAndPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_09_InitTokenAndPinTest.cs
@@ -54,7 +54,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                     slot.InitToken(Settings.SecurityOfficerPin, Settings.ApplicationName);
 
                     // Open RW session
-                    using (Session session = slot.OpenSession(false))
+                    using (Session session = slot.OpenSession(SessionType.ReadWrite))
                     {
                         // Login as SO (security officer)
                         session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_10_SetPinTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_10_SetPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_11_SeedAndGenerateRandomTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -66,7 +66,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_11_SeedAndGenerateRandomTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Mix additional seed material into the token's random number generator
                     byte[] seed = ConvertUtils.Utf8StringToBytes("Additional seed material");
@@ -72,7 +72,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get random or pseudo-random data
                     byte[] randomData = session.GenerateRandom(256);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_12_DigestTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_12_DigestTest.cs
@@ -48,7 +48,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -79,7 +79,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -115,7 +115,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_15_CreateCopyDestroyObjectTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -88,7 +88,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -123,7 +123,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_15_CreateCopyDestroyObjectTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -82,7 +82,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_16_GetAndSetAttributeValueTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -131,7 +131,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_16_GetAndSetAttributeValueTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -81,7 +81,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -125,7 +125,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_17_ObjectFindingTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_17_ObjectFindingTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_18_GenerateKeyAndKeyPairTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_18_GenerateKeyAndKeyPairTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_19_EncryptAndDecryptTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -91,7 +91,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -157,7 +157,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_19_EncryptAndDecryptTest.cs
@@ -49,7 +49,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -163,7 +163,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_20_SignAndVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_20_SignAndVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_21_SignAndVerifyRecoverTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_21_SignAndVerifyRecoverTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_24_WrapAndUnwrapKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_24_WrapAndUnwrapKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_25_DeriveKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_25_DeriveKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_26_LegacyParallelFunctionsTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_26_LegacyParallelFunctionsTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try
@@ -77,7 +77,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
             
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27_Pkcs11UriUtilsTest.cs
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                     throw new Exception("None of the slots matches PKCS#11 URI");
 
                 // Open read only session with first token that matches URI
-                using (Session session = slots[0].OpenSession(true))
+                using (Session session = slots[0].OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user with PIN acquired from URI
                     session.Login(CKU.CKU_USER, pkcs11Uri.PinValue);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27_Pkcs11UriUtilsTest.cs
@@ -101,7 +101,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
                 throw new Exception("PKCS#11 URI does not specify private key");
 
             // Load and initialize PKCS#11 library specified by URI
-            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, AppType.MultiThreaded))
             {
                 // Obtain a list of all slots with tokens that match URI
                 List<Slot> slots = Pkcs11UriUtils.GetMatchingSlotList(pkcs11Uri, pkcs11, true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27b_Pkcs11UriUtilsTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -154,7 +154,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -335,7 +335,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
                 List<Slot> allSlots = pkcs11.GetSlotList(true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI80/_27b_Pkcs11UriUtilsTest.cs
@@ -99,7 +99,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 SlotInfo slotInfo = slots[0].GetSlotInfo();
 
@@ -156,7 +156,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 TokenInfo tokenInfo = slots[0].GetTokenInfo();
 
@@ -338,7 +338,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI80
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
-                List<Slot> allSlots = pkcs11.GetSlotList(true);
+                List<Slot> allSlots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(allSlots != null && allSlots.Count > 0);
 
                 // Empty URI

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/Helpers.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/Helpers.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
         public static Slot GetUsableSlot(Pkcs11 pkcs11)
         {
             // Get list of available slots with token present
-            List<Slot> slots = pkcs11.GetSlotList(true);
+            List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
 
             Assert.IsNotNull(slots);
             Assert.IsTrue(slots.Count > 0);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_01_InitializeTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_01_InitializeTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             // Unmanaged PKCS#11 library is loaded by the constructor of Pkcs11 class.
             // Every PKCS#11 library needs to be initialized with C_Initialize method
             // which is also called automatically by the constructor of Pkcs11 class.
-            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking);
+            Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType);
             
             // Do something  interesting
             
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
 
             // Pkcs11 class can be used in using statement which defines a scope 
             // at the end of which an object will be disposed.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Do something interesting
             }
@@ -80,8 +80,8 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will not be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "false" as a value of "useOsLocking" parameter.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, false))
+            // simultaneously, it should specify "AppType.SingleThreaded" as a value of "appType" parameter.
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.SingleThreaded))
             {
                 // Do something interesting
             }
@@ -97,9 +97,9 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
             // If an application will be accessing PKCS#11 library from multiple threads
-            // simultaneously, it should specify "true" as a value of "useOsLocking" parameter.
+            // simultaneously, it should specify "AppType.MultiThreaded" as a value of "appType" parameter.
             // PKCS#11 library will use the native operation system threading model for locking.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, AppType.MultiThreaded))
             {
                 // Do something interesting
             }
@@ -121,7 +121,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI81.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithFunctionList))
             {
                 // Do something interesting
             }
@@ -143,7 +143,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             // The most simple constructor of Net.Pkcs11Interop.HighLevelAPI81.Pkcs11 class uses 
             // C_GetFunctionList() approach but Pkcs11Interop also provides an alternative constructor 
             // that can specify which approach should be used.
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking, false))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType, InitType.WithoutFunctionList))
             {
                 // Do something interesting
             }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_02_GetInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_02_GetInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_03_SlotListInfoAndEventTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -61,7 +61,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
                 List<Slot> slots = pkcs11.GetSlotList(false);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Wait for a slot event
                 bool eventOccured = false;

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_03_SlotListInfoAndEventTest.cs
@@ -92,7 +92,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 // Wait for a slot event
                 bool eventOccured = false;
                 ulong slotId = 0;
-                pkcs11.WaitForSlotEvent(true, out eventOccured, out slotId);
+                pkcs11.WaitForSlotEvent(WaitType.NonBlocking, out eventOccured, out slotId);
                 Assert.IsFalse(eventOccured);
             }
         }

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_03_SlotListInfoAndEventTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_03_SlotListInfoAndEventTest.cs
@@ -44,7 +44,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get list of available slots
-                List<Slot> slots = pkcs11.GetSlotList(false);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithOrWithoutTokenPresent);
                 
                 // Do something interesting with slots
                 Assert.IsNotNull(slots);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_04_TokenInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_04_TokenInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_05_MechanismListAndInfoTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_05_MechanismListAndInfoTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_06_SessionTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
 
                 // Do something interesting in RO session
 
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 
                 // Session class can be used in using statement which defines a scope 
                 // at the end of which the session will be closed automatically.
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -93,7 +93,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                Session session = slot.OpenSession(true);
+                Session session = slot.OpenSession(SessionType.ReadOnly);
                 
                 // Do something interesting in RO session
                 Assert.IsNotNull(session);
@@ -142,7 +142,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Do something interesting in RO session
                 }
@@ -164,7 +164,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW (read-write) session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Do something interesting in RW session
                 }
@@ -186,7 +186,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get session details
                     SessionInfo sessionInfo = session.GetSessionInfo();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_06_SessionTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_06_SessionTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -64,7 +64,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -111,7 +111,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -136,7 +136,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -158,7 +158,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -180,7 +180,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_07_OperationStateTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get operation state
                     byte[] state = session.GetOperationState();

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_07_OperationStateTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_07_OperationStateTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_08_LoginTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as SO (security officer)
                     session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_08_LoginTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_08_LoginTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -67,7 +67,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_09_InitTokenAndPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_09_InitTokenAndPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_09_InitTokenAndPinTest.cs
@@ -54,7 +54,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                     slot.InitToken(Settings.SecurityOfficerPin, Settings.ApplicationName);
 
                     // Open RW session
-                    using (Session session = slot.OpenSession(false))
+                    using (Session session = slot.OpenSession(SessionType.ReadWrite))
                     {
                         // Login as SO (security officer)
                         session.Login(CKU.CKU_SO, Settings.SecurityOfficerPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_10_SetPinTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_10_SetPinTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_10_SetPinTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_11_SeedAndGenerateRandomTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Mix additional seed material into the token's random number generator
                     byte[] seed = ConvertUtils.Utf8StringToBytes("Additional seed material");
@@ -72,7 +72,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Get random or pseudo-random data
                     byte[] randomData = session.GenerateRandom(256);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_11_SeedAndGenerateRandomTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_11_SeedAndGenerateRandomTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -66,7 +66,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_12_DigestTest.cs
@@ -48,7 +48,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -79,7 +79,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Specify digesting mechanism
                     Mechanism mechanism = new Mechanism(CKM.CKM_SHA_1);
@@ -115,7 +115,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_12_DigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_12_DigestTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -73,7 +73,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_15_CreateCopyDestroyObjectTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -88,7 +88,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -123,7 +123,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_15_CreateCopyDestroyObjectTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_15_CreateCopyDestroyObjectTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -82,7 +82,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -117,7 +117,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_16_GetAndSetAttributeValueTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -81,7 +81,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -125,7 +125,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_16_GetAndSetAttributeValueTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_16_GetAndSetAttributeValueTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -87,7 +87,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -131,7 +131,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_17_ObjectFindingTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_17_ObjectFindingTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_17_ObjectFindingTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_18_GenerateKeyAndKeyPairTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_18_GenerateKeyAndKeyPairTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_18_GenerateKeyAndKeyPairTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_19_EncryptAndDecryptTest.cs
@@ -49,7 +49,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -163,7 +163,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_19_EncryptAndDecryptTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_19_EncryptAndDecryptTest.cs
@@ -43,7 +43,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -91,7 +91,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -157,7 +157,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_20_SignAndVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -90,7 +90,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_20_SignAndVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_20_SignAndVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);
@@ -96,7 +96,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_21_SignAndVerifyRecoverTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_21_SignAndVerifyRecoverTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_21_SignAndVerifyRecoverTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_22_DigestEncryptAndDecryptDigestTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_22_DigestEncryptAndDecryptDigestTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_23_SignEncryptAndDecryptVerifyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_23_SignEncryptAndDecryptVerifyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_24_WrapAndUnwrapKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_24_WrapAndUnwrapKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_24_WrapAndUnwrapKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_25_DeriveKeyTest.cs
@@ -41,7 +41,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_25_DeriveKeyTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_25_DeriveKeyTest.cs
@@ -47,7 +47,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RW session
-                using (Session session = slot.OpenSession(false))
+                using (Session session = slot.OpenSession(SessionType.ReadWrite))
                 {
                     // Login as normal user
                     session.Login(CKU.CKU_USER, Settings.NormalUserPin);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_26_LegacyParallelFunctionsTest.cs
@@ -40,7 +40,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
@@ -71,7 +71,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Find first slot with token present
                 Slot slot = Helpers.GetUsableSlot(pkcs11);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_26_LegacyParallelFunctionsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_26_LegacyParallelFunctionsTest.cs
@@ -46,7 +46,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
                 
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try
@@ -77,7 +77,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 Slot slot = Helpers.GetUsableSlot(pkcs11);
             
                 // Open RO (read-only) session
-                using (Session session = slot.OpenSession(true))
+                using (Session session = slot.OpenSession(SessionType.ReadOnly))
                 {
                     // Legacy functions should always return CKR_FUNCTION_NOT_PARALLEL
                     try

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27_Pkcs11UriUtilsTest.cs
@@ -109,7 +109,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                     throw new Exception("None of the slots matches PKCS#11 URI");
 
                 // Open read only session with first token that matches URI
-                using (Session session = slots[0].OpenSession(true))
+                using (Session session = slots[0].OpenSession(SessionType.ReadOnly))
                 {
                     // Login as normal user with PIN acquired from URI
                     session.Login(CKU.CKU_USER, pkcs11Uri.PinValue);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27_Pkcs11UriUtilsTest.cs
@@ -101,7 +101,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
                 throw new Exception("PKCS#11 URI does not specify private key");
 
             // Load and initialize PKCS#11 library specified by URI
-            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, true))
+            using (Pkcs11 pkcs11 = new Pkcs11(pkcs11Uri.ModulePath, AppType.MultiThreaded))
             {
                 // Obtain a list of all slots with tokens that match URI
                 List<Slot> slots = Pkcs11UriUtils.GetMatchingSlotList(pkcs11Uri, pkcs11, true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27b_Pkcs11UriUtilsTest.cs
@@ -42,7 +42,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 LibraryInfo libraryInfo = pkcs11.GetInfo();
 
@@ -97,7 +97,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -154,7 +154,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 List<Slot> slots = pkcs11.GetSlotList(true);
                 Assert.IsTrue(slots != null && slots.Count > 0);
@@ -335,7 +335,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
                 List<Slot> allSlots = pkcs11.GetSlotList(true);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/HighLevelAPI81/_27b_Pkcs11UriUtilsTest.cs
@@ -99,7 +99,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 SlotInfo slotInfo = slots[0].GetSlotInfo();
 
@@ -156,7 +156,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
 
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
-                List<Slot> slots = pkcs11.GetSlotList(true);
+                List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(slots != null && slots.Count > 0);
                 TokenInfo tokenInfo = slots[0].GetTokenInfo();
 
@@ -338,7 +338,7 @@ namespace Net.Pkcs11Interop.Tests.HighLevelAPI81
             using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.AppType))
             {
                 // Get all slots
-                List<Slot> allSlots = pkcs11.GetSlotList(true);
+                List<Slot> allSlots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
                 Assert.IsTrue(allSlots != null && allSlots.Count > 0);
 
                 // Empty URI

--- a/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI40/_28b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI40/_28b_Pkcs11UriUtilsTest.cs
@@ -367,7 +367,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI40
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath))
             {
                 CKR rv = pkcs11.C_Initialize(Settings.InitArgs40);
                 Assert.IsTrue(rv == CKR.CKR_OK);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI41/_28b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI41/_28b_Pkcs11UriUtilsTest.cs
@@ -367,7 +367,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI41
             if (Platform.UnmanagedLongSize != 4 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath))
             {
                 CKR rv = pkcs11.C_Initialize(Settings.InitArgs41);
                 Assert.IsTrue(rv == CKR.CKR_OK);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI80/_28b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI80/_28b_Pkcs11UriUtilsTest.cs
@@ -367,7 +367,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI80
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 0)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath))
             {
                 CKR rv = pkcs11.C_Initialize(Settings.InitArgs80);
                 Assert.IsTrue(rv == CKR.CKR_OK);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI81/_28b_Pkcs11UriUtilsTest.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/LowLevelAPI81/_28b_Pkcs11UriUtilsTest.cs
@@ -367,7 +367,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI81
             if (Platform.UnmanagedLongSize != 8 || Platform.StructPackingSize != 1)
                 Assert.Inconclusive("Test cannot be executed on this platform");
 
-            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath, Settings.UseOsLocking))
+            using (Pkcs11 pkcs11 = new Pkcs11(Settings.Pkcs11LibraryPath))
             {
                 CKR rv = pkcs11.C_Initialize(Settings.InitArgs81);
                 Assert.IsTrue(rv == CKR.CKR_OK);

--- a/src/Pkcs11Interop/Pkcs11InteropTests/Settings.cs
+++ b/src/Pkcs11Interop/Pkcs11InteropTests/Settings.cs
@@ -43,10 +43,10 @@ namespace Net.Pkcs11Interop.Tests
         public static string Pkcs11LibraryPath = GetPkcs11MockLibraryPath();
 
         /// <summary>
-        /// Flag indicating whether PKCS#11 library should use its internal native threading model for locking.
-        /// This should be set to true in all multithreaded applications.
+        /// Type of application that will be using PKCS#11 library.
+        /// When set to AppType.MultiThreaded unmanaged PKCS#11 library performs locking to ensure thread safety.
         /// </summary>
-        public static bool UseOsLocking = true;
+        public static AppType AppType = AppType.MultiThreaded;
 
         /// <summary>
         /// Serial number of token (smartcard) that should be used by these tests.
@@ -132,7 +132,7 @@ namespace Net.Pkcs11Interop.Tests
             // Pkcs11LibraryPath = @"c:\pkcs11-logger-x86.dll";
 
             // Setup arguments passed to the C_Initialize function
-            if (UseOsLocking)
+            if (AppType == AppType.MultiThreaded)
             {
                 InitArgs40 = new LLA40.CK_C_INITIALIZE_ARGS();
                 InitArgs40.Flags = CKF.CKF_OS_LOCKING_OK;


### PR DESCRIPTION
Since we are already breaking assembly reference compatibility in #52 I am also going to explore the possibility of making API more user friendly.

This PR replaces several most annoying occurrences of `bool` type in public APIs with `enum` types. I believe that code with enums is not only easier to write but most importantly it is much easier to read.

Five new enums have been introduced:

## 1 - Net.Pkcs11Interop.Common.AppType

Previous code that initializes unmanaged PKCS#11 library in multi-threaded applications:

```csharp
Pkcs11 pkcs11 = new Pkcs11("pkcs11-mock-x64.dll", true);
```

Current code that initializes unmanaged PKCS#11 library in multi-threaded applications:

```csharp
Pkcs11 pkcs11 = new Pkcs11("pkcs11-mock-x64.dll", AppType.MultiThreaded);
```

## 2 - Net.Pkcs11Interop.Common.InitType

Previous code that initializes unmanaged PKCS#11 library with function pointers acquired with a single call of `C_GetFunctionList` function:

```csharp
Pkcs11 pkcs11 = new Pkcs11("pkcs11-mock-x64.dll", true, true);
```

Current code that initializes unmanaged PKCS#11 library with function pointers acquired with a single call of `C_GetFunctionList` function:

```csharp
Pkcs11 pkcs11 = new Pkcs11("pkcs11-mock-x64.dll", AppType.MultiThreaded, InitType.WithFunctionList);
```

## 3 - Net.Pkcs11Interop.Common.SlotsType

Previous code that obtains list of slots with token present:

```csharp
List<Slot> slots = pkcs11.GetSlotList(true);
```

Current code that obtains list of slots with token present:

```csharp
List<Slot> slots = pkcs11.GetSlotList(SlotsType.WithTokenPresent);
```

## 4 - Net.Pkcs11Interop.Common.WaitType

Previous code that analyzes slot events in non-blocking mode:

```csharp
pkcs11.WaitForSlotEvent(true, out bool eventOccured, out ulong slotId);
```

Current code that analyzes slot events in non-blocking mode:

```csharp
pkcs11.WaitForSlotEvent(WaitType.NonBlocking, out bool eventOccured, out ulong slotId);
```

## 5 - Net.Pkcs11Interop.Common.SessionType

Previous code that opens new read-only session:

```csharp
Session session = slot.OpenSession(true);
```

Current code that opens new read-only session:

```csharp
Session session = slot.OpenSession(SessionType.ReadOnly);
```