### PR TITLE
Configure CI for Linux and OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: csharp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      dotnet: 2.1.4
+      mono: none
+    - os: osx
+      osx_image: xcode9.3
+      dotnet: 2.1.4
+      mono: none
+
+branches:
+  only:
+    - master
+    - 4.x-maintenance
+
+script:
+  - dotnet --info
+  - dotnet restore ./src/Pkcs11Interop.NetStandard/
+  - dotnet build ./src/Pkcs11Interop.NetStandard/
+  - dotnet test -f netcoreapp2.0 ./src/Pkcs11Interop.NetStandard/Pkcs11Interop.DotNetCore.Tests/

--- a/src/Pkcs11Interop.NetStandard/Pkcs11Interop.DotNetCore.Tests/Pkcs11Interop.DotNetCore.Tests.csproj
+++ b/src/Pkcs11Interop.NetStandard/Pkcs11Interop.DotNetCore.Tests/Pkcs11Interop.DotNetCore.Tests.csproj
@@ -22,9 +22,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="NUnit" Version="3.6.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pkcs11Interop.NetStandard/Pkcs11Interop/Pkcs11Interop.csproj
+++ b/src/Pkcs11Interop.NetStandard/Pkcs11Interop/Pkcs11Interop.csproj
@@ -16,6 +16,9 @@
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Pkcs11Interop\Pkcs11Interop\Pkcs11Interop.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>


### PR DESCRIPTION
Use travis-ci.org to build and test netstandard2.0 version of Pkcs11Interop with .NET Core SDK 2.1.4 on Ubuntu and OS X