### PR TITLE
Use LoadLibraryEx to be able to find dependencies in the DLL:s directory

### DIFF
--- a/src/Pkcs11Interop/Common/NativeMethods.cs
+++ b/src/Pkcs11Interop/Common/NativeMethods.cs
@@ -42,9 +42,11 @@ namespace Net.Pkcs11Interop.Common
         /// Loads the specified module into the address space of the calling process.
         /// </summary>
         /// <param name="lpFileName">The name of the module.</param>
+        /// <param name="hFile">Reserved for future use, must be 0.</param>
+        /// <param name="dwFlags">Flags determining how the module is loaded.</param>
         /// <returns>If the function succeeds, the return value is a handle to the module. If the function fails, the return value is NULL.</returns>
         [DllImport("kernel32", CallingConvention = CallingConvention.Winapi, SetLastError = true, BestFitMapping = false, ThrowOnUnmappableChar = true)]
-        internal static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string lpFileName);
+        internal static extern IntPtr LoadLibraryEx([MarshalAs(UnmanagedType.LPStr)] string lpFileName, IntPtr hFile, uint dwFlags);
 
         /// <summary>
         /// Frees the loaded dynamic-link library (DLL) module and, if necessary, decrements its reference count.

--- a/src/Pkcs11Interop/Common/UnmanagedLibrary.cs
+++ b/src/Pkcs11Interop/Common/UnmanagedLibrary.cs
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Common
             else
             {
                 // Load library
-                libraryHandle = NativeMethods.LoadLibrary(fileName);
+                libraryHandle = NativeMethods.LoadLibraryEx(fileName, IntPtr.Zero, 0x00000008); // LOAD_WITH_ALTERED_SEARCH_PATH
                 if (libraryHandle == IntPtr.Zero)
                 {
                     int win32Error = Marshal.GetLastWin32Error();

--- a/src/Pkcs11Interop/Common/UnmanagedLibrary.cs
+++ b/src/Pkcs11Interop/Common/UnmanagedLibrary.cs
@@ -84,7 +84,7 @@ namespace Net.Pkcs11Interop.Common
             else
             {
                 // Load library
-                libraryHandle = NativeMethods.LoadLibraryEx(fileName, IntPtr.Zero, 0x00000008); // LOAD_WITH_ALTERED_SEARCH_PATH
+                libraryHandle = NativeMethods.LoadLibraryEx(Path.GetFullPath(fileName), IntPtr.Zero, 0x00000008); // LOAD_WITH_ALTERED_SEARCH_PATH
                 if (libraryHandle == IntPtr.Zero)
                 {
                     int win32Error = Marshal.GetLastWin32Error();


### PR DESCRIPTION
If the DLL you point to has dependencies in the same directory it won't load with LoadLibrary, as that directory is not on the library path. LoadLibraryEx with the LOAD_WITH_ALTERED_SEARCH_PATH flags searches that directory, so it works as one would expect.