### PR TITLE
Updated to fix an error with token from Cryptas and nCipher (attribute length can be 0xffffffff)

### DIFF
--- a/src/Pkcs11Interop/HighLevelAPI40/Session.cs
+++ b/src/Pkcs11Interop/HighLevelAPI40/Session.cs
@@ -613,6 +613,9 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             {
                 if (MiscSettings.AttributesWithNestedAttributes.ContainsKey(ConvertUtils.UInt32ToUInt64(template[i].type)))
                 {
+                    if (template[i].valueLen == UInt32.MaxValue)
+                        continue;
+
                     int ckAttributeSize = UnmanagedMemory.SizeOf(typeof(CK_ATTRIBUTE));
                     int nestedAttrCount = ConvertUtils.UInt32ToInt32(template[i].valueLen) / ckAttributeSize;
                     int nestedAttrCountMod = ConvertUtils.UInt32ToInt32(template[i].valueLen) % ckAttributeSize;

--- a/src/Pkcs11Interop/HighLevelAPI41/Session.cs
+++ b/src/Pkcs11Interop/HighLevelAPI41/Session.cs
@@ -613,6 +613,9 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             {
                 if (MiscSettings.AttributesWithNestedAttributes.ContainsKey(ConvertUtils.UInt32ToUInt64(template[i].type)))
                 {
+                    if (template[i].valueLen == UInt32.MaxValue)
+                        continue;
+
                     int ckAttributeSize = UnmanagedMemory.SizeOf(typeof(CK_ATTRIBUTE));
                     int nestedAttrCount = ConvertUtils.UInt32ToInt32(template[i].valueLen) / ckAttributeSize;
                     int nestedAttrCountMod = ConvertUtils.UInt32ToInt32(template[i].valueLen) % ckAttributeSize;

--- a/src/Pkcs11Interop/LowLevelAPI40/CkaUtils.cs
+++ b/src/Pkcs11Interop/LowLevelAPI40/CkaUtils.cs
@@ -578,7 +578,7 @@ namespace Net.Pkcs11Interop.LowLevelAPI40
         {
             byte[] value = null;
 
-            if (attribute.value != IntPtr.ZeroZero && attribute.valueLen != UInt32.MaxValue)
+            if (attribute.value != IntPtr.Zero && attribute.valueLen != UInt32.MaxValue)
                 value = UnmanagedMemory.Read(attribute.value, ConvertUtils.UInt32ToInt32(attribute.valueLen));
 
             return value;

--- a/src/Pkcs11Interop/LowLevelAPI40/CkaUtils.cs
+++ b/src/Pkcs11Interop/LowLevelAPI40/CkaUtils.cs
@@ -364,6 +364,12 @@ namespace Net.Pkcs11Interop.LowLevelAPI40
         /// <param name="value">Location that receives attribute value</param>
         public static void ConvertValue(ref CK_ATTRIBUTE attribute, out CK_ATTRIBUTE[] value)
         {
+            if (attribute.valueLen == UInt32.MaxValue)
+            {
+                value = null;
+                return;
+            }
+
             int ckAttributeSize = UnmanagedMemory.SizeOf(typeof(CK_ATTRIBUTE));
             int attrCount = ConvertUtils.UInt32ToInt32(attribute.valueLen) / ckAttributeSize;
             int attrCountMod = ConvertUtils.UInt32ToInt32(attribute.valueLen) % ckAttributeSize;
@@ -441,6 +447,12 @@ namespace Net.Pkcs11Interop.LowLevelAPI40
         /// <param name="value">Location that receives attribute value</param>
         public static void ConvertValue(ref CK_ATTRIBUTE attribute, out NativeULong[] value)
         {
+            if (attribute.valueLen == UInt32.MaxValue)
+            {
+                value = null;
+                return;
+            }
+
             int ckmSize = UnmanagedMemory.SizeOf(typeof(NativeULong));
             int attrCount = ConvertUtils.UInt32ToInt32(attribute.valueLen) / ckmSize;
             int attrCountMod = ConvertUtils.UInt32ToInt32(attribute.valueLen) % ckmSize;
@@ -566,7 +578,7 @@ namespace Net.Pkcs11Interop.LowLevelAPI40
         {
             byte[] value = null;
 
-            if (attribute.value != IntPtr.Zero)
+            if (attribute.value != IntPtr.ZeroZero && attribute.valueLen != UInt32.MaxValue)
                 value = UnmanagedMemory.Read(attribute.value, ConvertUtils.UInt32ToInt32(attribute.valueLen));
 
             return value;

--- a/src/Pkcs11Interop/LowLevelAPI41/CkaUtils.cs
+++ b/src/Pkcs11Interop/LowLevelAPI41/CkaUtils.cs
@@ -364,6 +364,12 @@ namespace Net.Pkcs11Interop.LowLevelAPI41
         /// <param name="value">Location that receives attribute value</param>
         public static void ConvertValue(ref CK_ATTRIBUTE attribute, out CK_ATTRIBUTE[] value)
         {
+            if (attribute.valueLen == UInt32.MaxValue)
+            {
+                value = null;
+                return;
+            }
+
             int ckAttributeSize = UnmanagedMemory.SizeOf(typeof(CK_ATTRIBUTE));
             int attrCount = ConvertUtils.UInt32ToInt32(attribute.valueLen) / ckAttributeSize;
             int attrCountMod = ConvertUtils.UInt32ToInt32(attribute.valueLen) % ckAttributeSize;
@@ -441,6 +447,12 @@ namespace Net.Pkcs11Interop.LowLevelAPI41
         /// <param name="value">Location that receives attribute value</param>
         public static void ConvertValue(ref CK_ATTRIBUTE attribute, out NativeULong[] value)
         {
+            if (attribute.valueLen == UInt32.MaxValue)
+            {
+                value = null;
+                return;
+            }
+
             int ckmSize = UnmanagedMemory.SizeOf(typeof(NativeULong));
             int attrCount = ConvertUtils.UInt32ToInt32(attribute.valueLen) / ckmSize;
             int attrCountMod = ConvertUtils.UInt32ToInt32(attribute.valueLen) % ckmSize;
@@ -566,7 +578,7 @@ namespace Net.Pkcs11Interop.LowLevelAPI41
         {
             byte[] value = null;
 
-            if (attribute.value != IntPtr.Zero)
+            if (attribute.value != IntPtr.Zero && attribute.valueLen != UInt32.MaxValue)
                 value = UnmanagedMemory.Read(attribute.value, ConvertUtils.UInt32ToInt32(attribute.valueLen));
 
             return value;


### PR DESCRIPTION

![error](https://user-images.githubusercontent.com/8501657/83013483-6491e480-a01d-11ea-8ee6-0e688a3c4945.png)

attribute length conversion cause an error in Pkcs11Admin tool with Cryptas or nCipher HSM