### PR TITLE
fix libdl name src/Pkcs11Interop/Pkcs11Interop/Common/NativeMethods.cs

### DIFF
--- a/src/Pkcs11Interop/Pkcs11Interop/Common/NativeMethods.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/Common/NativeMethods.cs
@@ -110,7 +110,7 @@ namespace Net.Pkcs11Interop.Common
 #if XAMARINMAC2_0
         private const string _dllName = "/usr/lib/libSystem.dylib";
 #else
-        private const string _dllName = "libdl";
+        private const string _dllName = "libdl.so.2";
 #endif
 
         /// <summary>


### PR DESCRIPTION
Hello,
Our [library](https://www-1.nuget.org/packages/Aktiv.RutokenPkcs11Interop/2.0.1) depends on your lib v4.1.1. We have noticed that applications linked with this lib have an error:

```
Unhandled exception. System.DllNotFoundException: Unable to load shared library 'libdl' or one of its dependencies. In order to help diagnose loading problems, consider setting the LD_DEBUG environment variable: liblibdl: cannot open shared object file: No such file or directory
   at Net.Pkcs11Interop.Common.NativeMethods.dlopen(String filename, Int32 flag)
   at Net.Pkcs11Interop.Common.UnmanagedLibrary.Load(String fileName)
   at Net.Pkcs11Interop.LowLevelAPI80.Pkcs11..ctor(String libraryPath)
   at Net.Pkcs11Interop.HighLevelAPI80.Pkcs11..ctor(String libraryPath, AppType appType)
   at Net.Pkcs11Interop.HighLevelAPI.Pkcs11..ctor(String libraryPath, AppType appType)
   at Aktiv.RtAdmin.Startup.RegisterServices(String nativeLibraryPath) in /home/lo1ol/rtadmin/Aktiv.RtAdmin/Startup.cs:line 51
   at Aktiv.RtAdmin.Startup.Configure(String logFilePath, String nativeLibraryPath) in /home/lo1ol/rtadmin/Aktiv.RtAdmin/Startup.cs:line 20
   at Aktiv.RtAdmin.RtAdmin.Main(String[] args) in /home/lo1ol/rtadmin/Aktiv.RtAdmin/Program.cs:line 48
Aborted (core dumped)
```

This problem can be solved by downloading package  libc6-dev or by creating sym link libdl.so to the library libdl.so.2.
Nevertheless, this solution isn't convenient for common users of our application.  We decided to change name of linked library by libdl.so.2. and this help. 
I don't know the purpose why the link to libdl.so doesn't exist by default, but inside all tested OSes libdl.so.2 exists always. 

If our solution is relevant, could you please  fix the current version of you project and create a new branch v4.1.2 with this fix for our library.