### PR TITLE
Fix encryption and decyption for streams

### DIFF
--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
@@ -937,13 +937,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
                 throw new Pkcs11Exception("C_DecryptInit", rv);
 
             byte[] encryptedPart = new byte[bufferLength];
-            byte[] part = new byte[bufferLength];
-            uint partLen = Convert.ToUInt32(part.Length);
+            byte[] part;
+            uint partLen = 0;
 
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(encryptedPart, 0, encryptedPart.Length)) > 0)
             {
-                partLen = Convert.ToUInt32(part.Length);
+                rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), null, ref partLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+                part = new  byte[partLen];
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
@@ -799,13 +799,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
                 throw new Pkcs11Exception("C_EncryptInit", rv);
 
             byte[] part = new byte[bufferLength];
-            byte[] encryptedPart = new byte[bufferLength];
-            uint encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
+            byte[] encryptedPart;
+            uint encryptedPartLen = 0;
             
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(part, 0, part.Length)) > 0)
             {
-                encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
+                rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), null, ref encryptedPartLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                encryptedPart = new byte[encryptedPartLen];
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
@@ -937,13 +937,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
                 throw new Pkcs11Exception("C_DecryptInit", rv);
 
             byte[] encryptedPart = new byte[bufferLength];
-            byte[] part = new byte[bufferLength];
-            uint partLen = Convert.ToUInt32(part.Length);
+            byte[] part;
+            uint partLen = 0;
 
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(encryptedPart, 0, encryptedPart.Length)) > 0)
             {
-                partLen = Convert.ToUInt32(part.Length);
+                rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), null, ref partLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+                part =  new byte[partLen];
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
@@ -799,13 +799,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
                 throw new Pkcs11Exception("C_EncryptInit", rv);
 
             byte[] part = new byte[bufferLength];
-            byte[] encryptedPart = new byte[bufferLength];
-            uint encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
+            byte[] encryptedPart;
+            uint encryptedPartLen = 0;
             
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(part, 0, part.Length)) > 0)
             {
-                encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
+                rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), null, ref encryptedPartLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                encryptedPart = new byte[encryptedPartLen];
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
@@ -799,13 +799,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
                 throw new Pkcs11Exception("C_EncryptInit", rv);
 
             byte[] part = new byte[bufferLength];
-            byte[] encryptedPart = new byte[bufferLength];
-            ulong encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
+            byte[] encryptedPart;
+            ulong encryptedPartLen = 0;
             
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(part, 0, part.Length)) > 0)
             {
-                encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
+                rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), null, ref encryptedPartLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                encryptedPart = new byte[encryptedPartLen];
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
@@ -937,13 +937,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
                 throw new Pkcs11Exception("C_DecryptInit", rv);
 
             byte[] encryptedPart = new byte[bufferLength];
-            byte[] part = new byte[bufferLength];
-            ulong partLen = Convert.ToUInt64(part.Length);
+            byte[] part;
+            ulong partLen = 0;
 
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(encryptedPart, 0, encryptedPart.Length)) > 0)
             {
-                partLen = Convert.ToUInt64(part.Length);
+                rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), null, ref partLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+                part = new byte[partLen];
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
@@ -937,13 +937,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
                 throw new Pkcs11Exception("C_DecryptInit", rv);
 
             byte[] encryptedPart = new byte[bufferLength];
-            byte[] part = new byte[bufferLength];
-            ulong partLen = Convert.ToUInt64(part.Length);
+            byte[] part;
+            ulong partLen = 0;
 
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(encryptedPart, 0, encryptedPart.Length)) > 0)
             {
-                partLen = Convert.ToUInt64(part.Length);
+                rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), null, ref partLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+		part = new byte[partLen];
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
@@ -799,13 +799,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
                 throw new Pkcs11Exception("C_EncryptInit", rv);
 
             byte[] part = new byte[bufferLength];
-            byte[] encryptedPart = new byte[bufferLength];
-            ulong encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
+            byte[] encryptedPart;
+            ulong encryptedPartLen = 0;
             
             int bytesRead = 0;
             while ((bytesRead = inputStream.Read(part, 0, part.Length)) > 0)
             {
-                encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
+                rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), null, ref encryptedPartLen);
+                if (rv != CKR.CKR_OK)
+                    throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                encryptedPart = new byte[encryptedPartLen];
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
                 if (rv != CKR.CKR_OK)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);


### PR DESCRIPTION
Hello,

[Our package](https://www.nuget.org/packages/Aktiv.RutokenPkcs11Interop/) depends on your package v. 4.1.1. Recently, we noticed that encryption and decryption doesn't work properly for streams. After viewing the sources, we've found the incorrect using of C_EncryptUpdate function inside Encrypt/Decrypt override for streams. The problem arises when length of output buffer doesn't equal to length of input buffer (such as inside my pkcs11 lib librtpkcs11ecp). So, I've creating a patch which resolve this problem by getting the length of the output buffer before encryption and decryption.

If the patch is right, I can create the same patch for 5.1.1 version (problem doesn't still resolve for it). But I'm waiting for that you will releases a new version 4.1.2 with this patch.