### PR TITLE
Enlarge the buffer for C_*EncryptUpdate and C_Decrypt*Update when needed

### DIFF
--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
@@ -807,8 +807,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             {
                 encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -941,8 +950,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             {
                 partLen = Convert.ToUInt32(part.Length);
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
@@ -1591,8 +1591,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             {
                 encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
                 rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -1746,8 +1755,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             {
                 partLen = Convert.ToUInt32(part.Length);
                 rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
@@ -959,7 +959,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
 
                     rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
                     if (rv != CKR.CKR_OK)
-                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                        throw new Pkcs11Exception("C_DecryptUpdate", rv);
                 }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI40/Session.cs
@@ -1931,8 +1931,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             {
                 encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
                 rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -2110,8 +2119,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI40
             {
                 partLen = Convert.ToUInt32(part.Length);
                 rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
@@ -807,8 +807,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             {
                 encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -941,8 +950,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             {
                 partLen = Convert.ToUInt32(part.Length);
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
@@ -1591,8 +1591,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             {
                 encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
                 rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -1746,8 +1755,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             {
                 partLen = Convert.ToUInt32(part.Length);
                 rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
@@ -1931,8 +1931,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             {
                 encryptedPartLen = Convert.ToUInt32(encryptedPart.Length);
                 rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt32(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -2110,8 +2119,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
             {
                 partLen = Convert.ToUInt32(part.Length);
                 rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI41/Session.cs
@@ -959,7 +959,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI41
 
                     rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt32(bytesRead), part, ref partLen);
                     if (rv != CKR.CKR_OK)
-                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                        throw new Pkcs11Exception("C_DecryptUpdate", rv);
                 }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
@@ -959,7 +959,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
 
                     rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
                     if (rv != CKR.CKR_OK)
-                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                        throw new Pkcs11Exception("C_DecryptUpdate", rv);
                 }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
@@ -1931,8 +1931,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             {
                 encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
                 rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -2110,8 +2119,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             {
                 partLen = Convert.ToUInt64(part.Length);
                 rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
@@ -807,8 +807,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             {
                 encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -941,8 +950,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             {
                 partLen = Convert.ToUInt64(part.Length);
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI80/Session.cs
@@ -1591,8 +1591,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             {
                 encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
                 rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -1746,8 +1755,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI80
             {
                 partLen = Convert.ToUInt64(part.Length);
                 rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
@@ -1931,8 +1931,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             {
                 encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
                 rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_SignEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_SignEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -2110,8 +2119,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             {
                 partLen = Convert.ToUInt64(part.Length);
                 rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptVerifyUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptVerifyUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
@@ -959,7 +959,7 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
 
                     rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
                     if (rv != CKR.CKR_OK)
-                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                        throw new Pkcs11Exception("C_DecryptUpdate", rv);
                 }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
@@ -807,8 +807,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             {
                 encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
                 rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_EncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_EncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -941,8 +950,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             {
                 partLen = Convert.ToUInt64(part.Length);
                 rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_EncryptUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }

--- a/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
+++ b/src/Pkcs11Interop/Pkcs11Interop/HighLevelAPI81/Session.cs
@@ -1591,8 +1591,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             {
                 encryptedPartLen = Convert.ToUInt64(encryptedPart.Length);
                 rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    encryptedPart = new byte[encryptedPartLen];
+
+                    rv = _p11.C_DigestEncryptUpdate(_sessionId, part, Convert.ToUInt64(bytesRead), encryptedPart, ref encryptedPartLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DigestEncryptUpdate", rv);
+                }
 
                 outputStream.Write(encryptedPart, 0, Convert.ToInt32(encryptedPartLen));
             }
@@ -1746,8 +1755,17 @@ namespace Net.Pkcs11Interop.HighLevelAPI81
             {
                 partLen = Convert.ToUInt64(part.Length);
                 rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
-                if (rv != CKR.CKR_OK)
+                if (rv != CKR.CKR_OK && rv != CKR.CKR_BUFFER_TOO_SMALL)
                     throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+
+                if (rv == CKR.CKR_BUFFER_TOO_SMALL)
+                {
+                    part = new byte[partLen];
+
+                    rv = _p11.C_DecryptDigestUpdate(_sessionId, encryptedPart, Convert.ToUInt64(bytesRead), part, ref partLen);
+                    if (rv != CKR.CKR_OK)
+                        throw new Pkcs11Exception("C_DecryptDigestUpdate", rv);
+                }
 
                 outputStream.Write(part, 0, Convert.ToInt32(partLen));
             }


### PR DESCRIPTION
Alternative implementation for https://github.com/Pkcs11Interop/Pkcs11Interop/pull/170 that should use less allocations.