### PR TITLE
Remove need for libc6-dev on known linux runtimes

### DIFF
--- a/src/Pkcs11Interop/Common/Platform.cs
+++ b/src/Pkcs11Interop/Common/Platform.cs
@@ -108,6 +108,44 @@ namespace Net.Pkcs11Interop.Common
         }
 
         /// <summary>
+        /// True if runtime is .NET (version >= 5.0) or .NET Core
+        /// </summary>
+        private static bool _isNetCore;
+
+        /// <summary>
+        /// True if runtime is .NET (version >= 5.0) or .NET Core
+        /// </summary>
+        public static bool IsNetCore
+        {
+            get
+            {
+                if (!_runtimeDetected)
+                    DetectRuntime();
+
+                return _isNetCore;
+            }
+        }
+
+        /// <summary>
+        /// True if runtime is Mono
+        /// </summary>
+        private static bool _isMono;
+
+        /// <summary>
+        /// True if runtime is Mono
+        /// </summary>
+        public static bool IsMono
+        {
+            get
+            {
+                if (!_runtimeDetected)
+                    DetectRuntime();
+
+                return _isMono;
+            }
+        }
+
+        /// <summary>
         /// Size of native (unmanaged) long type
         /// </summary>
         private static int _nativeULongSize = 0;
@@ -267,6 +305,28 @@ namespace Net.Pkcs11Interop.Common
             }
 
 #endif
+        }
+
+        /// <summary>
+        /// True if runtime detection was performed
+        /// </summary>
+        private static bool _runtimeDetected = false;
+
+        /// <summary>
+        /// Performs runtime detection
+        /// </summary>
+        private static void DetectRuntime()
+        {
+#if NETSTANDARD
+            _isNetCore = Environment.Version.Major >= 5 || 
+                         RuntimeInformation.FrameworkDescription.StartsWith(".NET Core");
+#else
+            _isNetCore = false;
+#endif
+
+            _isMono = Type.GetType("Mono.Runtime") != null;
+
+            _runtimeDetected = true;
         }
     }
 }


### PR DESCRIPTION
The current mechanism to dynamically load the PKCS#11 library on Linux (and macOS) requires `libc6-dev` to be installed on the target systems. It also requires the methods `dlopen` & co to be present in the `libld` library.

On some linux flavors (e.g. Ubuntu 22.04) `dlopen` & co were moved from `libld` to `libc`. Other systems may not have `libc6-dev` installed at all.

This PR proposes to leverage the runtimes packaging of the required functions to mitigate those (potential) issues. The solution is inspired by the dynamic loading implementation of the grpc library found here: https://github.com/grpc/grpc/blob/be80a7047bc5a2be19b994756060fda4d779d141/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs 

Merging this PR would allow the usage of the Pkcs#11Interop library on Ubuntu 22.04 and other linux flavors with atypical placement of the functions required to dynamically load libraries.