### PR TITLE
[5.2.0]: Added CKM_ECIES mechanism

### DIFF
--- a/src/Pkcs11Interop/Common/CKDHP.cs
+++ b/src/Pkcs11Interop/Common/CKDHP.cs
@@ -1,0 +1,36 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+// Note: Code in this file is maintained manually.
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Elliptic curve encryption, Diffie-Hellman primitives.
+    /// </summary>
+    public enum CKDHP : uint
+    {
+        /// <summary>
+        /// ECDH1 with COFACTOR (standard)
+        /// </summary>
+        CKDHP_STANDARD = 0x00000001
+    }
+}

--- a/src/Pkcs11Interop/Common/CKES.cs
+++ b/src/Pkcs11Interop/Common/CKES.cs
@@ -1,0 +1,56 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+// Note: Code in this file is maintained manually.
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Elliptic curve encryption
+    /// </summary>
+    public enum CKES : uint
+    {
+        /// <summary>
+        /// Elliptic curve encryption based on XOR
+        /// </summary>
+        CKES_XOR = 0x00000001,
+
+        /// <summary>
+        /// Elliptic curve encryption based on DES3_CBC_PAD
+        /// </summary>
+        CKES_DES3_CBC_PAD = 0x00000002,
+
+        /// <summary>
+        /// Elliptic curve encryption based on AES_CBC_PAD
+        /// </summary>
+        CKES_AES_CBC_PAD = 0x00000003,
+
+        /// <summary>
+        /// Elliptic curve encryption based on DES3_CBC
+        /// </summary>
+        CKES_DES3_CBC = 0x00000004,
+
+        /// <summary>
+        /// Elliptic curve encryption based on AES_CBC
+        /// </summary>
+        CKES_AES_CBC = 0x00000005
+    }
+}

--- a/src/Pkcs11Interop/Common/CKM.cs
+++ b/src/Pkcs11Interop/Common/CKM.cs
@@ -19,7 +19,6 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
-using System;
 
 // Note: Code in this file is maintained manually.
 
@@ -174,7 +173,7 @@ namespace Net.Pkcs11Interop.Common
         /// PKCS #1 v1.5 RSA signature with SHA-256 mechanism
         /// </summary>
         CKM_SHA256_RSA_PKCS = 0x00000040,
-        
+
         /// <summary>
         /// PKCS #1 v1.5 RSA signature with SHA-384 mechanism
         /// </summary>
@@ -289,7 +288,7 @@ namespace Net.Pkcs11Interop.Common
         /// Special case of general-length RC2-MAC mechanism
         /// </summary>
         CKM_RC2_MAC = 0x00000103,
-        
+
         /// <summary>
         /// General-length RC2-MAC mechanism based on data authentication as defined in FIPS PUB 113
         /// </summary>
@@ -334,7 +333,7 @@ namespace Net.Pkcs11Interop.Common
         /// General-length DES-MAC mechanism based on data authentication as defined in FIPS PUB 113
         /// </summary>
         CKM_DES_MAC_GENERAL = 0x00000124,
-        
+
         /// <summary>
         /// DES-CBC encryption mechanism with cipher-block chaining mode (CBC) and PKCS#7 padding
         /// </summary>
@@ -344,7 +343,7 @@ namespace Net.Pkcs11Interop.Common
         /// Double-length DES key generation mechanism
         /// </summary>
         CKM_DES2_KEY_GEN = 0x00000130,
-        
+
         /// <summary>
         /// Triple-length DES key generation mechanism
         /// </summary>
@@ -604,7 +603,7 @@ namespace Net.Pkcs11Interop.Common
         /// CAST key generation mechanism
         /// </summary>
         CKM_CAST_KEY_GEN = 0x00000300,
-        
+
         /// <summary>
         /// CAST-ECB encryption mechanism with electronic codebook mode (ECB)
         /// </summary>
@@ -629,7 +628,7 @@ namespace Net.Pkcs11Interop.Common
         /// CAST-CBC encryption mechanism with cipher-block chaining mode (CBC) and PKCS#7 padding
         /// </summary>
         CKM_CAST_CBC_PAD = 0x00000305,
-        
+
         /// <summary>
         /// CAST3 key generation mechanism
         /// </summary>
@@ -644,7 +643,7 @@ namespace Net.Pkcs11Interop.Common
         /// CAST3-CBC encryption mechanism with cipher-block chaining mode (CBC)
         /// </summary>
         CKM_CAST3_CBC = 0x00000312,
-        
+
         /// <summary>
         /// Special case of general-length CAST3-MAC mechanism
         /// </summary>
@@ -659,7 +658,7 @@ namespace Net.Pkcs11Interop.Common
         /// CAST3-CBC encryption mechanism with cipher-block chaining mode (CBC) and PKCS#7 padding
         /// </summary>
         CKM_CAST3_CBC_PAD = 0x00000315,
-        
+
         /// <summary>
         /// CAST128 key generation mechanism
         /// </summary>
@@ -719,7 +718,7 @@ namespace Net.Pkcs11Interop.Common
         /// CAST128-CBC encryption mechanism with cipher-block chaining mode (CBC) and PKCS#7 padding
         /// </summary>
         CKM_CAST128_CBC_PAD = 0x00000325,
-        
+
         /// <summary>
         /// RC5 key generation mechanism
         /// </summary>
@@ -749,7 +748,7 @@ namespace Net.Pkcs11Interop.Common
         /// RC5-CBC encryption mechanism with cipher-block chaining mode (CBC) and PKCS#7 padding
         /// </summary>
         CKM_RC5_CBC_PAD = 0x00000335,
-        
+
         /// <summary>
         /// IDEA key generation mechanism
         /// </summary>
@@ -779,7 +778,7 @@ namespace Net.Pkcs11Interop.Common
         /// IDEA-CBC encryption mechanism with cipher-block chaining mode (CBC) and PKCS#7 padding
         /// </summary>
         CKM_IDEA_CBC_PAD = 0x00000345,
-        
+
         /// <summary>
         /// The generic secret key generation mechanism
         /// </summary>
@@ -801,7 +800,7 @@ namespace Net.Pkcs11Interop.Common
         CKM_CONCATENATE_DATA_AND_BASE = 0x00000363,
 
         /// <summary>
-        /// Key derivation mechanism that 
+        /// Key derivation mechanism that
         /// </summary>
         CKM_XOR_BASE_AND_DATA = 0x00000364,
 
@@ -814,7 +813,7 @@ namespace Net.Pkcs11Interop.Common
         /// Mechanism for pre_master key generation in SSL 3.0
         /// </summary>
         CKM_SSL3_PRE_MASTER_KEY_GEN = 0x00000370,
-        
+
         /// <summary>
         /// Mechanism for master key derivation in SSL 3.0
         /// </summary>
@@ -884,17 +883,17 @@ namespace Net.Pkcs11Interop.Common
         /// SHA-256 key derivation mechanism
         /// </summary>
         CKM_SHA256_KEY_DERIVATION = 0x00000393,
-        
+
         /// <summary>
         /// SHA-384 key derivation mechanism
         /// </summary>
         CKM_SHA384_KEY_DERIVATION = 0x00000394,
-        
+
         /// <summary>
         /// SHA-512 key derivation mechanism
         /// </summary>
         CKM_SHA512_KEY_DERIVATION = 0x00000395,
-        
+
         /// <summary>
         /// SHA-224 key derivation mechanism
         /// </summary>
@@ -1084,12 +1083,12 @@ namespace Net.Pkcs11Interop.Common
         /// The CT-KIP key wrap and unwrap mechanism
         /// </summary>
         CKM_KIP_WRAP = 0x00000511,
-        
+
         /// <summary>
         /// The CT-KIP signature (MAC) mechanism
         /// </summary>
         CKM_KIP_MAC = 0x00000512,
-        
+
         /// <summary>
         /// The Camellia key generation mechanism
         /// </summary>
@@ -1119,7 +1118,7 @@ namespace Net.Pkcs11Interop.Common
         /// Camellia-CBC encryption mechanism with cipher-block chaining mode (CBC) and PKCS#7 padding
         /// </summary>
         CKM_CAMELLIA_CBC_PAD = 0x00000555,
-        
+
         /// <summary>
         /// Key derivation mechanism based on Camellia-ECB encryption mechanism with electronic codebook mode (ECB)
         /// </summary>
@@ -1134,7 +1133,7 @@ namespace Net.Pkcs11Interop.Common
         /// Camellia-CTR mechanism for encryption and decryption with CAMELLIA in counter mode
         /// </summary>
         CKM_CAMELLIA_CTR = 0x00000558,
-        
+
         /// <summary>
         /// The ARIA key generation mechanism
         /// </summary>
@@ -1289,7 +1288,7 @@ namespace Net.Pkcs11Interop.Common
         /// The FORTEZZA timestamp mechanism
         /// </summary>
         CKM_FORTEZZA_TIMESTAMP = 0x00001020,
-        
+
         /// <summary>
         /// The BATON key generation mechanism
         /// </summary>
@@ -1324,7 +1323,7 @@ namespace Net.Pkcs11Interop.Common
         /// BATON mechanism for wrapping and unwrapping of secret keys (MEK)
         /// </summary>
         CKM_BATON_WRAP = 0x00001036,
-        
+
         /// <summary>
         /// The EC (also related to ECDSA) key pair generation mechanism
         /// </summary>
@@ -1364,6 +1363,11 @@ namespace Net.Pkcs11Interop.Common
         /// The ECDSA with SHA-512 mechanism
         /// </summary>
         CKM_ECDSA_SHA512 = 0x00001046,
+
+        /// <summary>
+        /// The ECIES mechanism
+        /// </summary>
+        CKM_ECIES = 0x80000A00,
 
         /// <summary>
         /// The elliptic curve Diffie-Hellman (ECDH) key derivation mechanism

--- a/src/Pkcs11Interop/Common/CKMS.cs
+++ b/src/Pkcs11Interop/Common/CKMS.cs
@@ -1,0 +1,91 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+// Note: Code in this file is maintained manually.
+
+namespace Net.Pkcs11Interop.Common
+{
+    /// <summary>
+    /// Elliptic curve encryption, MAC Scheme to be used.
+    /// </summary>
+    public enum CKMS : uint
+    {
+        /// <summary>
+        /// MAC Scheme based on HMAC_SHA1
+        /// </summary>
+        CKMS_HMAC_SHA1 = 0x00000001,
+
+        /// <summary>
+        /// MAC Scheme based on SHA1
+        /// </summary>
+        CKMS_SHA1 = 0x00000002,
+
+        /// <summary>
+        /// MAC Scheme based on HMAC_SHA224
+        /// </summary>
+        CKMS_HMAC_SHA224 = 0x00000003,
+
+        /// <summary>
+        /// MAC Scheme based on SHA224
+        /// </summary>
+        CKMS_SHA224 = 0x00000004,
+
+        /// <summary>
+        /// MAC Scheme based on HMAC_SHA256
+        /// </summary>
+        CKMS_HMAC_SHA256 = 0x00000005,
+
+        /// <summary>
+        /// MAC Scheme based on SHA256
+        /// </summary>
+        CKMS_SHA256 = 0x00000006,
+
+        /// <summary>
+        /// MAC Scheme based on HMAC_SHA384
+        /// </summary>
+        CKMS_HMAC_SHA384 = 0x00000007,
+
+        /// <summary>
+        /// MAC Scheme based on SHA384
+        /// </summary>
+        CKMS_SHA384 = 0x00000008,
+
+        /// <summary>
+        /// MAC Scheme based on HMAC_SHA512
+        /// </summary>
+        CKMS_HMAC_SHA512 = 0x00000009,
+
+        /// <summary>
+        /// MAC Scheme based on SHA512
+        /// </summary>
+        CKMS_SHA512 = 0x0000000A,
+
+        /// <summary>
+        /// MAC Scheme based on HMAC_RIPEMD160
+        /// </summary>
+        CKMS_HMAC_RIPEMD160 = 0x0000000B,
+
+        /// <summary>
+        /// MAC Scheme based on RIPEMD160
+        /// </summary>
+        CKMS_RIPEMD160 = 0x0000000C
+    }
+}

--- a/src/Pkcs11Interop/HighLevelAPI/Factories/IMechanismParamsFactory.cs
+++ b/src/Pkcs11Interop/HighLevelAPI/Factories/IMechanismParamsFactory.cs
@@ -19,8 +19,8 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
-using System.Collections.Generic;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
+using System.Collections.Generic;
 
 // Note: Code in this file is maintained manually.
 
@@ -554,5 +554,20 @@ namespace Net.Pkcs11Interop.HighLevelAPI.Factories
         /// <param name='publicKey'>Handle to the first party's ephemeral public key</param>
         /// <returns>Parameters for the CKM_X9_42_MQV_DERIVE key derivation mechanism</returns>
         ICkX942MqvDeriveParams CreateCkX942MqvDeriveParams(ulong kdf, byte[] otherInfo, byte[] publicData, ulong privateDataLen, IObjectHandle privateData, byte[] publicData2, IObjectHandle publicKey);
+
+        /// <summary>
+        /// Creates parameters for the CKM_ECIES mechanism
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        /// <returns>Parameters for the CKM_ECIES mechanism</returns>
+        ICkEciesParams CreateCkEciesParams(ulong dhPrimitive, ulong kdf, byte[] sharedData1, ulong encScheme, ulong encKeyLenInBits, ulong macScheme, ulong macKeyLenInBits, ulong macLenInBits, byte[] sharedData2);
     }
 }

--- a/src/Pkcs11Interop/HighLevelAPI/Factories/MechanismParamsFactory.cs
+++ b/src/Pkcs11Interop/HighLevelAPI/Factories/MechanismParamsFactory.cs
@@ -19,9 +19,9 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
-using System.Collections.Generic;
 using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
+using System.Collections.Generic;
 
 // Note: Code in this file is maintained manually.
 
@@ -748,6 +748,24 @@ namespace Net.Pkcs11Interop.HighLevelAPI.Factories
         public ICkX942MqvDeriveParams CreateCkX942MqvDeriveParams(ulong kdf, byte[] otherInfo, byte[] publicData, ulong privateDataLen, IObjectHandle privateData, byte[] publicData2, IObjectHandle publicKey)
         {
             return _factory.CreateCkX942MqvDeriveParams(kdf, otherInfo, publicData, privateDataLen, privateData, publicData2, publicKey);
+        }
+
+        /// <summary>
+        /// Creates parameters for the CKM_ECIES mechanism
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        /// <returns>Parameters for the CKM_ECIES mechanism</returns>
+        public ICkEciesParams CreateCkEciesParams(ulong dhPrimitive, ulong kdf, byte[] sharedData1, ulong encScheme, ulong encKeyLenInBits, ulong macScheme, ulong macKeyLenInBits, ulong macLenInBits, byte[] sharedData2)
+        {
+            return _factory.CreateCkEciesParams(dhPrimitive, kdf, sharedData1, encScheme, encKeyLenInBits, macScheme, macKeyLenInBits, macLenInBits, sharedData2);
         }
     }
 }

--- a/src/Pkcs11Interop/HighLevelAPI/MechanismParams/ICkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI/MechanismParams/ICkEciesParams.cs
@@ -1,0 +1,30 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+namespace Net.Pkcs11Interop.HighLevelAPI.MechanismParams
+{
+    /// <summary>
+    /// Parameters for the CKM_ECIES mechanism
+    /// </summary>
+    public interface ICkEciesParams : IMechanismParams
+    {
+    }
+}

--- a/src/Pkcs11Interop/HighLevelAPI40/Factories/MechanismParamsFactory.cs
+++ b/src/Pkcs11Interop/HighLevelAPI40/Factories/MechanismParamsFactory.cs
@@ -19,12 +19,12 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
-using System.Collections.Generic;
 using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.HighLevelAPI.Factories;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
 using Net.Pkcs11Interop.HighLevelAPI40.MechanismParams;
+using System.Collections.Generic;
 
 // Note: Code in this file is generated automatically.
 
@@ -725,6 +725,24 @@ namespace Net.Pkcs11Interop.HighLevelAPI40.Factories
         public ICkX942MqvDeriveParams CreateCkX942MqvDeriveParams(ulong kdf, byte[] otherInfo, byte[] publicData, ulong privateDataLen, IObjectHandle privateData, byte[] publicData2, IObjectHandle publicKey)
         {
             return new CkX942MqvDeriveParams(ConvertUtils.UInt32FromUInt64(kdf), otherInfo, publicData, ConvertUtils.UInt32FromUInt64(privateDataLen), privateData, publicData2, publicKey);
+        }
+
+        /// <summary>
+        /// Creates parameters for the CKM_ECIES mechanism
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        /// <returns>Parameters for the CKM_ECIES mechanism</returns>
+        public ICkEciesParams CreateCkEciesParams(ulong dhPrimitive, ulong kdf, byte[] sharedData1, ulong encScheme, ulong encKeyLenInBits, ulong macScheme, ulong macKeyLenInBits, ulong macLenInBits, byte[] sharedData2)
+        {
+            return new CkEciesParams(ConvertUtils.UInt32FromUInt64(dhPrimitive), ConvertUtils.UInt32FromUInt64(kdf), sharedData1, ConvertUtils.UInt32FromUInt64(encScheme), ConvertUtils.UInt32FromUInt64(encKeyLenInBits), ConvertUtils.UInt32FromUInt64(macScheme), ConvertUtils.UInt32FromUInt64(macKeyLenInBits), ConvertUtils.UInt32FromUInt64(macLenInBits), sharedData2);
         }
     }
 }

--- a/src/Pkcs11Interop/HighLevelAPI40/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI40/MechanismParams/CkEciesParams.cs
@@ -1,0 +1,151 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using Net.Pkcs11Interop.Common;
+using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
+using Net.Pkcs11Interop.LowLevelAPI40.MechanismParams;
+using System;
+using NativeULong = System.UInt32;
+
+namespace Net.Pkcs11Interop.HighLevelAPI40.MechanismParams
+{
+    internal class CkEciesParams : ICkEciesParams
+    {
+        /// <summary>
+        /// Flag indicating whether instance has been disposed
+        /// </summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Low level mechanism parameters
+        /// </summary>
+        private CK_ECIES_PARAMS _lowLevelStruct = new CK_ECIES_PARAMS();
+
+        /// <summary>
+        /// Initializes a new instance of the CkEciesParams class.
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        public CkEciesParams(NativeULong dhPrimitive, NativeULong kdf, byte[] sharedData1, NativeULong encScheme, NativeULong encKeyLenInBits, NativeULong macScheme, NativeULong macKeyLenInBits, NativeULong macLenInBits, byte[] sharedData2)
+        {
+            _lowLevelStruct.DhPrimitive = 0;
+            _lowLevelStruct.Kdf = 0;
+            _lowLevelStruct.SharedDataLen1 = 0;
+            _lowLevelStruct.SharedData1 = IntPtr.Zero;
+            _lowLevelStruct.EncScheme = 0;
+            _lowLevelStruct.EncKeyLenInBits = 0;
+            _lowLevelStruct.MacScheme = 0;
+            _lowLevelStruct.MacKeyLenInBits = 0;
+            _lowLevelStruct.MacLenInBits = 0;
+            _lowLevelStruct.SharedDataLen2 = 0;
+            _lowLevelStruct.SharedData2 = IntPtr.Zero;
+
+            _lowLevelStruct.DhPrimitive = dhPrimitive;
+            _lowLevelStruct.Kdf = kdf;
+            _lowLevelStruct.EncScheme = encScheme;
+            _lowLevelStruct.EncKeyLenInBits = encKeyLenInBits;
+            _lowLevelStruct.MacScheme = macScheme;
+            _lowLevelStruct.MacKeyLenInBits = macKeyLenInBits;
+            _lowLevelStruct.MacLenInBits = macLenInBits;
+
+            if (sharedData1 != null)
+            {
+                _lowLevelStruct.SharedData1 = UnmanagedMemory.Allocate(sharedData1.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData1, sharedData1);
+                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt32FromInt32(sharedData1.Length);
+            }
+
+            if (sharedData2 != null)
+            {
+                _lowLevelStruct.SharedData2 = UnmanagedMemory.Allocate(sharedData2.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData2, sharedData2);
+                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt32FromInt32(sharedData2.Length);
+            }
+        }
+
+        #region IMechanismParams
+
+        /// <summary>
+        /// Returns managed object that can be marshaled to an unmanaged block of memory
+        /// </summary>
+        /// <returns>A managed object holding the data to be marshaled. This object must be an instance of a formatted class.</returns>
+        public object ToMarshalableStructure()
+        {
+            if (this._disposed)
+                throw new ObjectDisposedException(this.GetType().FullName);
+
+            return _lowLevelStruct;
+        }
+
+        #endregion IMechanismParams
+
+        #region IDisposable
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        /// <param name="disposing">Flag indicating whether managed resources should be disposed</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this._disposed)
+            {
+                if (disposing)
+                {
+                    // Dispose managed objects
+                }
+
+                // Dispose unmanaged objects
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData1);
+                _lowLevelStruct.SharedDataLen1 = 0;
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData2);
+                _lowLevelStruct.SharedDataLen2 = 0;
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Class destructor that disposes object if caller forgot to do so
+        /// </summary>
+        ~CkEciesParams()
+        {
+            Dispose(false);
+        }
+
+        #endregion IDisposable
+    }
+}

--- a/src/Pkcs11Interop/HighLevelAPI40/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI40/MechanismParams/CkEciesParams.cs
@@ -27,7 +27,10 @@ using NativeULong = System.UInt32;
 
 namespace Net.Pkcs11Interop.HighLevelAPI40.MechanismParams
 {
-    internal class CkEciesParams : ICkEciesParams
+    /// <summary>
+    /// Parameters for the CKM_ECIES mechanism
+    /// </summary>
+    public class CkEciesParams : ICkEciesParams
     {
         /// <summary>
         /// Flag indicating whether instance has been disposed

--- a/src/Pkcs11Interop/HighLevelAPI41/Factories/MechanismParamsFactory.cs
+++ b/src/Pkcs11Interop/HighLevelAPI41/Factories/MechanismParamsFactory.cs
@@ -19,12 +19,12 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
-using System.Collections.Generic;
 using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.HighLevelAPI.Factories;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
 using Net.Pkcs11Interop.HighLevelAPI41.MechanismParams;
+using System.Collections.Generic;
 
 // Note: Code in this file is maintained manually.
 
@@ -725,6 +725,24 @@ namespace Net.Pkcs11Interop.HighLevelAPI41.Factories
         public ICkX942MqvDeriveParams CreateCkX942MqvDeriveParams(ulong kdf, byte[] otherInfo, byte[] publicData, ulong privateDataLen, IObjectHandle privateData, byte[] publicData2, IObjectHandle publicKey)
         {
             return new CkX942MqvDeriveParams(ConvertUtils.UInt32FromUInt64(kdf), otherInfo, publicData, ConvertUtils.UInt32FromUInt64(privateDataLen), privateData, publicData2, publicKey);
+        }
+
+        /// <summary>
+        /// Creates parameters for the CKM_ECIES mechanism
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        /// <returns>Parameters for the CKM_ECIES mechanism</returns>
+        public ICkEciesParams CreateCkEciesParams(ulong dhPrimitive, ulong kdf, byte[] sharedData1, ulong encScheme, ulong encKeyLenInBits, ulong macScheme, ulong macKeyLenInBits, ulong macLenInBits, byte[] sharedData2)
+        {
+            return new CkEciesParams(ConvertUtils.UInt32FromUInt64(dhPrimitive), ConvertUtils.UInt32FromUInt64(kdf), sharedData1, ConvertUtils.UInt32FromUInt64(encScheme), ConvertUtils.UInt32FromUInt64(encKeyLenInBits), ConvertUtils.UInt32FromUInt64(macScheme), ConvertUtils.UInt32FromUInt64(macKeyLenInBits), ConvertUtils.UInt32FromUInt64(macLenInBits), sharedData2);
         }
     }
 }

--- a/src/Pkcs11Interop/HighLevelAPI41/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI41/MechanismParams/CkEciesParams.cs
@@ -27,7 +27,10 @@ using NativeULong = System.UInt32;
 
 namespace Net.Pkcs11Interop.HighLevelAPI41.MechanismParams
 {
-    internal class CkEciesParams : ICkEciesParams
+    /// <summary>
+    /// Parameters for the CKM_ECIES mechanism
+    /// </summary>
+    public class CkEciesParams : ICkEciesParams
     {
         /// <summary>
         /// Flag indicating whether instance has been disposed

--- a/src/Pkcs11Interop/HighLevelAPI41/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI41/MechanismParams/CkEciesParams.cs
@@ -1,0 +1,151 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using Net.Pkcs11Interop.Common;
+using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
+using Net.Pkcs11Interop.LowLevelAPI41.MechanismParams;
+using System;
+using NativeULong = System.UInt32;
+
+namespace Net.Pkcs11Interop.HighLevelAPI41.MechanismParams
+{
+    internal class CkEciesParams : ICkEciesParams
+    {
+        /// <summary>
+        /// Flag indicating whether instance has been disposed
+        /// </summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Low level mechanism parameters
+        /// </summary>
+        private CK_ECIES_PARAMS _lowLevelStruct = new CK_ECIES_PARAMS();
+
+        /// <summary>
+        /// Initializes a new instance of the CkEciesParams class.
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        public CkEciesParams(NativeULong dhPrimitive, NativeULong kdf, byte[] sharedData1, NativeULong encScheme, NativeULong encKeyLenInBits, NativeULong macScheme, NativeULong macKeyLenInBits, NativeULong macLenInBits, byte[] sharedData2)
+        {
+            _lowLevelStruct.DhPrimitive = 0;
+            _lowLevelStruct.Kdf = 0;
+            _lowLevelStruct.SharedDataLen1 = 0;
+            _lowLevelStruct.SharedData1 = IntPtr.Zero;
+            _lowLevelStruct.EncScheme = 0;
+            _lowLevelStruct.EncKeyLenInBits = 0;
+            _lowLevelStruct.MacScheme = 0;
+            _lowLevelStruct.MacKeyLenInBits = 0;
+            _lowLevelStruct.MacLenInBits = 0;
+            _lowLevelStruct.SharedDataLen2 = 0;
+            _lowLevelStruct.SharedData2 = IntPtr.Zero;
+
+            _lowLevelStruct.DhPrimitive = dhPrimitive;
+            _lowLevelStruct.Kdf = kdf;
+            _lowLevelStruct.EncScheme = encScheme;
+            _lowLevelStruct.EncKeyLenInBits = encKeyLenInBits;
+            _lowLevelStruct.MacScheme = macScheme;
+            _lowLevelStruct.MacKeyLenInBits = macKeyLenInBits;
+            _lowLevelStruct.MacLenInBits = macLenInBits;
+
+            if (sharedData1 != null)
+            {
+                _lowLevelStruct.SharedData1 = UnmanagedMemory.Allocate(sharedData1.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData1, sharedData1);
+                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt32FromInt32(sharedData1.Length);
+            }
+
+            if (sharedData2 != null)
+            {
+                _lowLevelStruct.SharedData2 = UnmanagedMemory.Allocate(sharedData2.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData2, sharedData2);
+                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt32FromInt32(sharedData2.Length);
+            }
+        }
+
+        #region IMechanismParams
+
+        /// <summary>
+        /// Returns managed object that can be marshaled to an unmanaged block of memory
+        /// </summary>
+        /// <returns>A managed object holding the data to be marshaled. This object must be an instance of a formatted class.</returns>
+        public object ToMarshalableStructure()
+        {
+            if (this._disposed)
+                throw new ObjectDisposedException(this.GetType().FullName);
+
+            return _lowLevelStruct;
+        }
+
+        #endregion IMechanismParams
+
+        #region IDisposable
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        /// <param name="disposing">Flag indicating whether managed resources should be disposed</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this._disposed)
+            {
+                if (disposing)
+                {
+                    // Dispose managed objects
+                }
+
+                // Dispose unmanaged objects
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData1);
+                _lowLevelStruct.SharedDataLen1 = 0;
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData2);
+                _lowLevelStruct.SharedDataLen2 = 0;
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Class destructor that disposes object if caller forgot to do so
+        /// </summary>
+        ~CkEciesParams()
+        {
+            Dispose(false);
+        }
+
+        #endregion IDisposable
+    }
+}

--- a/src/Pkcs11Interop/HighLevelAPI80/Factories/MechanismParamsFactory.cs
+++ b/src/Pkcs11Interop/HighLevelAPI80/Factories/MechanismParamsFactory.cs
@@ -19,12 +19,12 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
-using System.Collections.Generic;
 using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.HighLevelAPI.Factories;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
 using Net.Pkcs11Interop.HighLevelAPI80.MechanismParams;
+using System.Collections.Generic;
 
 // Note: Code in this file is generated automatically.
 
@@ -725,6 +725,24 @@ namespace Net.Pkcs11Interop.HighLevelAPI80.Factories
         public ICkX942MqvDeriveParams CreateCkX942MqvDeriveParams(ulong kdf, byte[] otherInfo, byte[] publicData, ulong privateDataLen, IObjectHandle privateData, byte[] publicData2, IObjectHandle publicKey)
         {
             return new CkX942MqvDeriveParams(ConvertUtils.UInt64FromUInt64(kdf), otherInfo, publicData, ConvertUtils.UInt64FromUInt64(privateDataLen), privateData, publicData2, publicKey);
+        }
+
+        /// <summary>
+        /// Creates parameters for the CKM_ECIES mechanism
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        /// <returns>Parameters for the CKM_ECIES mechanism</returns>
+        public ICkEciesParams CreateCkEciesParams(ulong dhPrimitive, ulong kdf, byte[] sharedData1, ulong encScheme, ulong encKeyLenInBits, ulong macScheme, ulong macKeyLenInBits, ulong macLenInBits, byte[] sharedData2)
+        {
+            return new CkEciesParams(ConvertUtils.UInt64FromUInt64(dhPrimitive), ConvertUtils.UInt64FromUInt64(kdf), sharedData1, ConvertUtils.UInt64FromUInt64(encScheme), ConvertUtils.UInt64FromUInt64(encKeyLenInBits), ConvertUtils.UInt64FromUInt64(macScheme), ConvertUtils.UInt64FromUInt64(macKeyLenInBits), ConvertUtils.UInt64FromUInt64(macLenInBits), sharedData2);
         }
     }
 }

--- a/src/Pkcs11Interop/HighLevelAPI80/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI80/MechanismParams/CkEciesParams.cs
@@ -27,7 +27,10 @@ using NativeULong = System.UInt64;
 
 namespace Net.Pkcs11Interop.HighLevelAPI80.MechanismParams
 {
-    internal class CkEciesParams : ICkEciesParams
+    /// <summary>
+    /// Parameters for the CKM_ECIES mechanism
+    /// </summary>
+    public class CkEciesParams : ICkEciesParams
     {
         /// <summary>
         /// Flag indicating whether instance has been disposed

--- a/src/Pkcs11Interop/HighLevelAPI80/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI80/MechanismParams/CkEciesParams.cs
@@ -77,14 +77,14 @@ namespace Net.Pkcs11Interop.HighLevelAPI80.MechanismParams
             {
                 _lowLevelStruct.SharedData1 = UnmanagedMemory.Allocate(sharedData1.Length);
                 UnmanagedMemory.Write(_lowLevelStruct.SharedData1, sharedData1);
-                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt32FromInt32(sharedData1.Length);
+                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt64FromInt32(sharedData1.Length);
             }
 
             if (sharedData2 != null)
             {
                 _lowLevelStruct.SharedData2 = UnmanagedMemory.Allocate(sharedData2.Length);
                 UnmanagedMemory.Write(_lowLevelStruct.SharedData2, sharedData2);
-                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt32FromInt32(sharedData2.Length);
+                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt64FromInt32(sharedData2.Length);
             }
         }
 

--- a/src/Pkcs11Interop/HighLevelAPI80/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI80/MechanismParams/CkEciesParams.cs
@@ -1,0 +1,151 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using Net.Pkcs11Interop.Common;
+using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
+using Net.Pkcs11Interop.LowLevelAPI80.MechanismParams;
+using System;
+using NativeULong = System.UInt64;
+
+namespace Net.Pkcs11Interop.HighLevelAPI80.MechanismParams
+{
+    internal class CkEciesParams : ICkEciesParams
+    {
+        /// <summary>
+        /// Flag indicating whether instance has been disposed
+        /// </summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Low level mechanism parameters
+        /// </summary>
+        private CK_ECIES_PARAMS _lowLevelStruct = new CK_ECIES_PARAMS();
+
+        /// <summary>
+        /// Initializes a new instance of the CkEciesParams class.
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        public CkEciesParams(NativeULong dhPrimitive, NativeULong kdf, byte[] sharedData1, NativeULong encScheme, NativeULong encKeyLenInBits, NativeULong macScheme, NativeULong macKeyLenInBits, NativeULong macLenInBits, byte[] sharedData2)
+        {
+            _lowLevelStruct.DhPrimitive = 0;
+            _lowLevelStruct.Kdf = 0;
+            _lowLevelStruct.SharedDataLen1 = 0;
+            _lowLevelStruct.SharedData1 = IntPtr.Zero;
+            _lowLevelStruct.EncScheme = 0;
+            _lowLevelStruct.EncKeyLenInBits = 0;
+            _lowLevelStruct.MacScheme = 0;
+            _lowLevelStruct.MacKeyLenInBits = 0;
+            _lowLevelStruct.MacLenInBits = 0;
+            _lowLevelStruct.SharedDataLen2 = 0;
+            _lowLevelStruct.SharedData2 = IntPtr.Zero;
+
+            _lowLevelStruct.DhPrimitive = dhPrimitive;
+            _lowLevelStruct.Kdf = kdf;
+            _lowLevelStruct.EncScheme = encScheme;
+            _lowLevelStruct.EncKeyLenInBits = encKeyLenInBits;
+            _lowLevelStruct.MacScheme = macScheme;
+            _lowLevelStruct.MacKeyLenInBits = macKeyLenInBits;
+            _lowLevelStruct.MacLenInBits = macLenInBits;
+
+            if (sharedData1 != null)
+            {
+                _lowLevelStruct.SharedData1 = UnmanagedMemory.Allocate(sharedData1.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData1, sharedData1);
+                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt32FromInt32(sharedData1.Length);
+            }
+
+            if (sharedData2 != null)
+            {
+                _lowLevelStruct.SharedData2 = UnmanagedMemory.Allocate(sharedData2.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData2, sharedData2);
+                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt32FromInt32(sharedData2.Length);
+            }
+        }
+
+        #region IMechanismParams
+
+        /// <summary>
+        /// Returns managed object that can be marshaled to an unmanaged block of memory
+        /// </summary>
+        /// <returns>A managed object holding the data to be marshaled. This object must be an instance of a formatted class.</returns>
+        public object ToMarshalableStructure()
+        {
+            if (this._disposed)
+                throw new ObjectDisposedException(this.GetType().FullName);
+
+            return _lowLevelStruct;
+        }
+
+        #endregion IMechanismParams
+
+        #region IDisposable
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        /// <param name="disposing">Flag indicating whether managed resources should be disposed</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this._disposed)
+            {
+                if (disposing)
+                {
+                    // Dispose managed objects
+                }
+
+                // Dispose unmanaged objects
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData1);
+                _lowLevelStruct.SharedDataLen1 = 0;
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData2);
+                _lowLevelStruct.SharedDataLen2 = 0;
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Class destructor that disposes object if caller forgot to do so
+        /// </summary>
+        ~CkEciesParams()
+        {
+            Dispose(false);
+        }
+
+        #endregion IDisposable
+    }
+}

--- a/src/Pkcs11Interop/HighLevelAPI81/Factories/MechanismParamsFactory.cs
+++ b/src/Pkcs11Interop/HighLevelAPI81/Factories/MechanismParamsFactory.cs
@@ -19,12 +19,12 @@
  *  Jaroslav IMRICH <jimrich@jimrich.sk>
  */
 
-using System.Collections.Generic;
 using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.HighLevelAPI.Factories;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
 using Net.Pkcs11Interop.HighLevelAPI81.MechanismParams;
+using System.Collections.Generic;
 
 // Note: Code in this file is generated automatically.
 
@@ -725,6 +725,24 @@ namespace Net.Pkcs11Interop.HighLevelAPI81.Factories
         public ICkX942MqvDeriveParams CreateCkX942MqvDeriveParams(ulong kdf, byte[] otherInfo, byte[] publicData, ulong privateDataLen, IObjectHandle privateData, byte[] publicData2, IObjectHandle publicKey)
         {
             return new CkX942MqvDeriveParams(ConvertUtils.UInt64FromUInt64(kdf), otherInfo, publicData, ConvertUtils.UInt64FromUInt64(privateDataLen), privateData, publicData2, publicKey);
+        }
+
+        /// <summary>
+        /// Creates parameters for the CKM_ECIES mechanism
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        /// <returns>Parameters for the CKM_ECIES mechanism</returns>
+        public ICkEciesParams CreateCkEciesParams(ulong dhPrimitive, ulong kdf, byte[] sharedData1, ulong encScheme, ulong encKeyLenInBits, ulong macScheme, ulong macKeyLenInBits, ulong macLenInBits, byte[] sharedData2)
+        {
+            return new CkEciesParams(ConvertUtils.UInt64FromUInt64(dhPrimitive), ConvertUtils.UInt64FromUInt64(kdf), sharedData1, ConvertUtils.UInt64FromUInt64(encScheme), ConvertUtils.UInt64FromUInt64(encKeyLenInBits), ConvertUtils.UInt64FromUInt64(macScheme), ConvertUtils.UInt64FromUInt64(macKeyLenInBits), ConvertUtils.UInt64FromUInt64(macLenInBits), sharedData2);
         }
     }
 }

--- a/src/Pkcs11Interop/HighLevelAPI81/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI81/MechanismParams/CkEciesParams.cs
@@ -77,14 +77,14 @@ namespace Net.Pkcs11Interop.HighLevelAPI81.MechanismParams
             {
                 _lowLevelStruct.SharedData1 = UnmanagedMemory.Allocate(sharedData1.Length);
                 UnmanagedMemory.Write(_lowLevelStruct.SharedData1, sharedData1);
-                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt32FromInt32(sharedData1.Length);
+                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt64FromInt32(sharedData1.Length);
             }
 
             if (sharedData2 != null)
             {
                 _lowLevelStruct.SharedData2 = UnmanagedMemory.Allocate(sharedData2.Length);
                 UnmanagedMemory.Write(_lowLevelStruct.SharedData2, sharedData2);
-                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt32FromInt32(sharedData2.Length);
+                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt64FromInt32(sharedData2.Length);
             }
         }
 

--- a/src/Pkcs11Interop/HighLevelAPI81/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI81/MechanismParams/CkEciesParams.cs
@@ -27,7 +27,10 @@ using NativeULong = System.UInt64;
 
 namespace Net.Pkcs11Interop.HighLevelAPI81.MechanismParams
 {
-    internal class CkEciesParams : ICkEciesParams
+    /// <summary>
+    /// Parameters for the CKM_ECIES mechanism
+    /// </summary>
+    public class CkEciesParams : ICkEciesParams
     {
         /// <summary>
         /// Flag indicating whether instance has been disposed

--- a/src/Pkcs11Interop/HighLevelAPI81/MechanismParams/CkEciesParams.cs
+++ b/src/Pkcs11Interop/HighLevelAPI81/MechanismParams/CkEciesParams.cs
@@ -1,0 +1,151 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using Net.Pkcs11Interop.Common;
+using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
+using Net.Pkcs11Interop.LowLevelAPI81.MechanismParams;
+using System;
+using NativeULong = System.UInt64;
+
+namespace Net.Pkcs11Interop.HighLevelAPI81.MechanismParams
+{
+    internal class CkEciesParams : ICkEciesParams
+    {
+        /// <summary>
+        /// Flag indicating whether instance has been disposed
+        /// </summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        /// Low level mechanism parameters
+        /// </summary>
+        private CK_ECIES_PARAMS _lowLevelStruct = new CK_ECIES_PARAMS();
+
+        /// <summary>
+        /// Initializes a new instance of the CkEciesParams class.
+        /// </summary>
+        /// <param name="dhPrimitive">Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value</param>
+        /// <param name="kdf">Key derivation function used on the shared secret value (CKD)</param>
+        /// <param name="sharedData1">The key derivation padding data shared between the two parties</param>
+        /// <param name="encScheme">The encryption scheme (CKES) used to transform the input data</param>
+        /// <param name="encKeyLenInBits">The bit length of the key to use for the encryption scheme</param>
+        /// <param name="macScheme">The MAC scheme (CKMS) used for MAC generation or validation</param>
+        /// <param name="macKeyLenInBits">The bit length of the key to use for the MAC scheme</param>
+        /// <param name="macLenInBits">The bit length of the MAC scheme output</param>
+        /// <param name="sharedData2">The MAC padding data shared between the two parties</param>
+        public CkEciesParams(NativeULong dhPrimitive, NativeULong kdf, byte[] sharedData1, NativeULong encScheme, NativeULong encKeyLenInBits, NativeULong macScheme, NativeULong macKeyLenInBits, NativeULong macLenInBits, byte[] sharedData2)
+        {
+            _lowLevelStruct.DhPrimitive = 0;
+            _lowLevelStruct.Kdf = 0;
+            _lowLevelStruct.SharedDataLen1 = 0;
+            _lowLevelStruct.SharedData1 = IntPtr.Zero;
+            _lowLevelStruct.EncScheme = 0;
+            _lowLevelStruct.EncKeyLenInBits = 0;
+            _lowLevelStruct.MacScheme = 0;
+            _lowLevelStruct.MacKeyLenInBits = 0;
+            _lowLevelStruct.MacLenInBits = 0;
+            _lowLevelStruct.SharedDataLen2 = 0;
+            _lowLevelStruct.SharedData2 = IntPtr.Zero;
+
+            _lowLevelStruct.DhPrimitive = dhPrimitive;
+            _lowLevelStruct.Kdf = kdf;
+            _lowLevelStruct.EncScheme = encScheme;
+            _lowLevelStruct.EncKeyLenInBits = encKeyLenInBits;
+            _lowLevelStruct.MacScheme = macScheme;
+            _lowLevelStruct.MacKeyLenInBits = macKeyLenInBits;
+            _lowLevelStruct.MacLenInBits = macLenInBits;
+
+            if (sharedData1 != null)
+            {
+                _lowLevelStruct.SharedData1 = UnmanagedMemory.Allocate(sharedData1.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData1, sharedData1);
+                _lowLevelStruct.SharedDataLen1 = ConvertUtils.UInt32FromInt32(sharedData1.Length);
+            }
+
+            if (sharedData2 != null)
+            {
+                _lowLevelStruct.SharedData2 = UnmanagedMemory.Allocate(sharedData2.Length);
+                UnmanagedMemory.Write(_lowLevelStruct.SharedData2, sharedData2);
+                _lowLevelStruct.SharedDataLen2 = ConvertUtils.UInt32FromInt32(sharedData2.Length);
+            }
+        }
+
+        #region IMechanismParams
+
+        /// <summary>
+        /// Returns managed object that can be marshaled to an unmanaged block of memory
+        /// </summary>
+        /// <returns>A managed object holding the data to be marshaled. This object must be an instance of a formatted class.</returns>
+        public object ToMarshalableStructure()
+        {
+            if (this._disposed)
+                throw new ObjectDisposedException(this.GetType().FullName);
+
+            return _lowLevelStruct;
+        }
+
+        #endregion IMechanismParams
+
+        #region IDisposable
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes object
+        /// </summary>
+        /// <param name="disposing">Flag indicating whether managed resources should be disposed</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this._disposed)
+            {
+                if (disposing)
+                {
+                    // Dispose managed objects
+                }
+
+                // Dispose unmanaged objects
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData1);
+                _lowLevelStruct.SharedDataLen1 = 0;
+                UnmanagedMemory.Free(ref _lowLevelStruct.SharedData2);
+                _lowLevelStruct.SharedDataLen2 = 0;
+
+                _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// Class destructor that disposes object if caller forgot to do so
+        /// </summary>
+        ~CkEciesParams()
+        {
+            Dispose(false);
+        }
+
+        #endregion IDisposable
+    }
+}

--- a/src/Pkcs11Interop/LowLevelAPI40/MechanismParams/CK_ECIES_PARAMS.cs
+++ b/src/Pkcs11Interop/LowLevelAPI40/MechanismParams/CK_ECIES_PARAMS.cs
@@ -1,0 +1,89 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using System;
+using System.Runtime.InteropServices;
+using NativeULong = System.UInt32;
+
+namespace Net.Pkcs11Interop.LowLevelAPI40.MechanismParams
+{
+    /// <summary>
+    /// Structure that provides the parameters for the CKM_ECIES mechanism
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 0, CharSet = CharSet.Unicode)]
+    public struct CK_ECIES_PARAMS
+    {
+        /// <summary>
+        /// Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value
+        /// </summary>
+        public NativeULong DhPrimitive;
+
+        /// <summary>
+        /// Key derivation function used on the shared secret value (CKD)
+        /// </summary>
+        public NativeULong Kdf;
+
+        /// <summary>
+        /// The length in bytes of the key derivation shared data
+        /// </summary>
+        public NativeULong SharedDataLen1;
+
+        /// <summary>
+        /// The key derivation padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData1;
+
+        /// <summary>
+        /// The encryption scheme (CKES) used to transform the input data
+        /// </summary>
+        public NativeULong EncScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the encryption scheme
+        /// </summary>
+        public NativeULong EncKeyLenInBits;
+
+        /// <summary>
+        /// The MAC scheme (CKMS) used for MAC generation or validation
+        /// </summary>
+        public NativeULong MacScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the MAC scheme
+        /// </summary>
+        public NativeULong MacKeyLenInBits;
+
+        /// <summary>
+        /// The bit length of the MAC scheme output
+        /// </summary>
+        public NativeULong MacLenInBits;
+
+        /// <summary>
+        /// The length in bytes of the MAC shared data
+        /// </summary>
+        public NativeULong SharedDataLen2;
+
+        /// <summary>
+        /// The MAC padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData2;
+    }
+}

--- a/src/Pkcs11Interop/LowLevelAPI41/MechanismParams/CK_ECIES_PARAMS.cs
+++ b/src/Pkcs11Interop/LowLevelAPI41/MechanismParams/CK_ECIES_PARAMS.cs
@@ -1,0 +1,89 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using System;
+using System.Runtime.InteropServices;
+using NativeULong = System.UInt32;
+
+namespace Net.Pkcs11Interop.LowLevelAPI41.MechanismParams
+{
+    /// <summary>
+    /// Structure that provides the parameters for the CKM_ECIES mechanism
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Unicode)]
+    public struct CK_ECIES_PARAMS
+    {
+        /// <summary>
+        /// Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value
+        /// </summary>
+        public NativeULong DhPrimitive;
+
+        /// <summary>
+        /// Key derivation function used on the shared secret value (CKD)
+        /// </summary>
+        public NativeULong Kdf;
+
+        /// <summary>
+        /// The length in bytes of the key derivation shared data
+        /// </summary>
+        public NativeULong SharedDataLen1;
+
+        /// <summary>
+        /// The key derivation padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData1;
+
+        /// <summary>
+        /// The encryption scheme (CKES) used to transform the input data
+        /// </summary>
+        public NativeULong EncScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the encryption scheme
+        /// </summary>
+        public NativeULong EncKeyLenInBits;
+
+        /// <summary>
+        /// The MAC scheme (CKMS) used for MAC generation or validation
+        /// </summary>
+        public NativeULong MacScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the MAC scheme
+        /// </summary>
+        public NativeULong MacKeyLenInBits;
+
+        /// <summary>
+        /// The bit length of the MAC scheme output
+        /// </summary>
+        public NativeULong MacLenInBits;
+
+        /// <summary>
+        /// The length in bytes of the MAC shared data
+        /// </summary>
+        public NativeULong SharedDataLen2;
+
+        /// <summary>
+        /// The MAC padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData2;
+    }
+}

--- a/src/Pkcs11Interop/LowLevelAPI80/MechanismParams/CK_ECIES_PARAMS.cs
+++ b/src/Pkcs11Interop/LowLevelAPI80/MechanismParams/CK_ECIES_PARAMS.cs
@@ -1,0 +1,89 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using System;
+using System.Runtime.InteropServices;
+using NativeULong = System.UInt64;
+
+namespace Net.Pkcs11Interop.LowLevelAPI80.MechanismParams
+{
+    /// <summary>
+    /// Structure that provides the parameters for the CKM_ECIES mechanism
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 0, CharSet = CharSet.Unicode)]
+    public struct CK_ECIES_PARAMS
+    {
+        /// <summary>
+        /// Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value
+        /// </summary>
+        public NativeULong DhPrimitive;
+
+        /// <summary>
+        /// Key derivation function used on the shared secret value (CKD)
+        /// </summary>
+        public NativeULong Kdf;
+
+        /// <summary>
+        /// The length in bytes of the key derivation shared data
+        /// </summary>
+        public NativeULong SharedDataLen1;
+
+        /// <summary>
+        /// The key derivation padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData1;
+
+        /// <summary>
+        /// The encryption scheme (CKES) used to transform the input data
+        /// </summary>
+        public NativeULong EncScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the encryption scheme
+        /// </summary>
+        public NativeULong EncKeyLenInBits;
+
+        /// <summary>
+        /// The MAC scheme (CKMS) used for MAC generation or validation
+        /// </summary>
+        public NativeULong MacScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the MAC scheme
+        /// </summary>
+        public NativeULong MacKeyLenInBits;
+
+        /// <summary>
+        /// The bit length of the MAC scheme output
+        /// </summary>
+        public NativeULong MacLenInBits;
+
+        /// <summary>
+        /// The length in bytes of the MAC shared data
+        /// </summary>
+        public NativeULong SharedDataLen2;
+
+        /// <summary>
+        /// The MAC padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData2;
+    }
+}

--- a/src/Pkcs11Interop/LowLevelAPI81/MechanismParams/CK_ECIES_PARAMS.cs
+++ b/src/Pkcs11Interop/LowLevelAPI81/MechanismParams/CK_ECIES_PARAMS.cs
@@ -1,0 +1,89 @@
+﻿/*
+ *  Copyright 2012-2021 The Pkcs11Interop Project
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Written for the Pkcs11Interop project by:
+ *  KhaledGomaa <khaledgomaa670@gmail.com>
+ */
+
+using System;
+using System.Runtime.InteropServices;
+using NativeULong = System.UInt64;
+
+namespace Net.Pkcs11Interop.LowLevelAPI81.MechanismParams
+{
+    /// <summary>
+    /// Structure that provides the parameters for the CKM_ECIES mechanism
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Pack = 1, CharSet = CharSet.Unicode)]
+    public struct CK_ECIES_PARAMS
+    {
+        /// <summary>
+        /// Diffie-Hellman Primitive (CKDHP) used to derive the shared secret value
+        /// </summary>
+        public NativeULong DhPrimitive;
+
+        /// <summary>
+        /// Key derivation function used on the shared secret value (CKD)
+        /// </summary>
+        public NativeULong Kdf;
+
+        /// <summary>
+        /// The length in bytes of the key derivation shared data
+        /// </summary>
+        public NativeULong SharedDataLen1;
+
+        /// <summary>
+        /// The key derivation padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData1;
+
+        /// <summary>
+        /// The encryption scheme (CKES) used to transform the input data
+        /// </summary>
+        public NativeULong EncScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the encryption scheme
+        /// </summary>
+        public NativeULong EncKeyLenInBits;
+
+        /// <summary>
+        /// The MAC scheme (CKMS) used for MAC generation or validation
+        /// </summary>
+        public NativeULong MacScheme;
+
+        /// <summary>
+        /// The bit length of the key to use for the MAC scheme
+        /// </summary>
+        public NativeULong MacKeyLenInBits;
+
+        /// <summary>
+        /// The bit length of the MAC scheme output
+        /// </summary>
+        public NativeULong MacLenInBits;
+
+        /// <summary>
+        /// The length in bytes of the MAC shared data
+        /// </summary>
+        public NativeULong SharedDataLen2;
+
+        /// <summary>
+        /// The MAC padding data shared between the two parties
+        /// </summary>
+        public IntPtr SharedData2;
+    }
+}

--- a/src/Pkcs11Interop/Pkcs11Interop.csproj
+++ b/src/Pkcs11Interop/Pkcs11Interop.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>5.1.2</Version>
+    <Version>5.2.0</Version>
     <Authors>Jaroslav Imrich</Authors>
     <Description>Managed .NET wrapper for unmanaged PKCS#11 libraries</Description>
     <Copyright>Copyright (c) 2012-2021 The Pkcs11Interop Project</Copyright>


### PR DESCRIPTION
The PR includes adding the support of CKM_ECIES mechanism,
Includes the following:

- CKM_ECIES mechanism
- Introduced new enums for enc scheme(CKES) ,mac scheme(CKMS) and DhPrimitives (CKDHP)
- Added create Ecies params for high levels to mechanism factory.
- Added low levels struct for ECIES_params.