### PR TITLE
Don't throw in `CK_VERSION::ToString`

### DIFF
--- a/src/Pkcs11Interop.Tests/LowLevelAPI40/_50_MiscellaneousTests.cs
+++ b/src/Pkcs11Interop.Tests/LowLevelAPI40/_50_MiscellaneousTests.cs
@@ -63,15 +63,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI40
                     }
                     else
                     {
-                        try
-                        {
-                            version.ToString();
-                            Assert.Fail("Exception expected but not thrown");
-                        }
-                        catch (Exception ex)
-                        {
-                            Assert.IsTrue(ex.Message == "Minor part of CK_VERSION exceeds the allowed maximum");
-                        }
+                        Assert.IsTrue(version.ToString() == "Invalid version");
                     }
                 }
             }

--- a/src/Pkcs11Interop.Tests/LowLevelAPI41/_50_MiscellaneousTests.cs
+++ b/src/Pkcs11Interop.Tests/LowLevelAPI41/_50_MiscellaneousTests.cs
@@ -63,15 +63,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI41
                     }
                     else
                     {
-                        try
-                        {
-                            version.ToString();
-                            Assert.Fail("Exception expected but not thrown");
-                        }
-                        catch (Exception ex)
-                        {
-                            Assert.IsTrue(ex.Message == "Minor part of CK_VERSION exceeds the allowed maximum");
-                        }
+                        Assert.IsTrue(version.ToString() == "Invalid version");
                     }
                 }
             }

--- a/src/Pkcs11Interop.Tests/LowLevelAPI80/_50_MiscellaneousTests.cs
+++ b/src/Pkcs11Interop.Tests/LowLevelAPI80/_50_MiscellaneousTests.cs
@@ -63,15 +63,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI80
                     }
                     else
                     {
-                        try
-                        {
-                            version.ToString();
-                            Assert.Fail("Exception expected but not thrown");
-                        }
-                        catch (Exception ex)
-                        {
-                            Assert.IsTrue(ex.Message == "Minor part of CK_VERSION exceeds the allowed maximum");
-                        }
+                        Assert.IsTrue(version.ToString() == "Invalid version");
                     }
                 }
             }

--- a/src/Pkcs11Interop.Tests/LowLevelAPI81/_50_MiscellaneousTests.cs
+++ b/src/Pkcs11Interop.Tests/LowLevelAPI81/_50_MiscellaneousTests.cs
@@ -63,15 +63,7 @@ namespace Net.Pkcs11Interop.Tests.LowLevelAPI81
                     }
                     else
                     {
-                        try
-                        {
-                            version.ToString();
-                            Assert.Fail("Exception expected but not thrown");
-                        }
-                        catch (Exception ex)
-                        {
-                            Assert.IsTrue(ex.Message == "Minor part of CK_VERSION exceeds the allowed maximum");
-                        }
+                        Assert.IsTrue(version.ToString() == "Invalid version");
                     }
                 }
             }

--- a/src/Pkcs11Interop/LowLevelAPI40/CK_VERSION.cs
+++ b/src/Pkcs11Interop/LowLevelAPI40/CK_VERSION.cs
@@ -60,7 +60,7 @@ namespace Net.Pkcs11Interop.LowLevelAPI40
             }
             else
             {
-                throw new Exception("Minor part of CK_VERSION exceeds the allowed maximum");
+                return "Invalid version";
             }
         }
     }

--- a/src/Pkcs11Interop/LowLevelAPI41/CK_VERSION.cs
+++ b/src/Pkcs11Interop/LowLevelAPI41/CK_VERSION.cs
@@ -60,7 +60,7 @@ namespace Net.Pkcs11Interop.LowLevelAPI41
             }
             else
             {
-                throw new Exception("Minor part of CK_VERSION exceeds the allowed maximum");
+                return "Invalid version";
             }
         }
     }

--- a/src/Pkcs11Interop/LowLevelAPI80/CK_VERSION.cs
+++ b/src/Pkcs11Interop/LowLevelAPI80/CK_VERSION.cs
@@ -60,7 +60,7 @@ namespace Net.Pkcs11Interop.LowLevelAPI80
             }
             else
             {
-                throw new Exception("Minor part of CK_VERSION exceeds the allowed maximum");
+                return "Invalid version";
             }
         }
     }

--- a/src/Pkcs11Interop/LowLevelAPI81/CK_VERSION.cs
+++ b/src/Pkcs11Interop/LowLevelAPI81/CK_VERSION.cs
@@ -60,7 +60,7 @@ namespace Net.Pkcs11Interop.LowLevelAPI81
             }
             else
             {
-                throw new Exception("Minor part of CK_VERSION exceeds the allowed maximum");
+                return "Invalid version";
             }
         }
     }


### PR DESCRIPTION
The changes introduced in the `CK_VERSION::ToString` method as part of #244 have proven to be too disruptive. This method plays a crucial role in various parts of Pkcs11Interop, facilitating conversions from LowLevelAPIs to HighLevelAPIs. If `CK_VERSION::ToString` throws an exception, several essential methods might become unusable. Examples include `IPkcs11Library::GetInfo`, `ISlot::GetTokenInfo`, and `ISlot::GetSlotInfo`.